### PR TITLE
chore: release v0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -779,7 +779,7 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "sacp"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "agent-client-protocol-schema",
  "anyhow",
@@ -798,7 +798,7 @@ dependencies = [
 
 [[package]]
 name = "sacp-conductor"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "agent-client-protocol-schema",
  "anyhow",
@@ -822,7 +822,7 @@ dependencies = [
 
 [[package]]
 name = "sacp-proxy"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "agent-client-protocol-schema",
  "chrono",

--- a/src/sacp-conductor/CHANGELOG.md
+++ b/src/sacp-conductor/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/symposium-dev/symposium-acp/compare/sacp-conductor-v0.1.0...sacp-conductor-v0.1.1) - 2025-10-30
+
+### Fixed
+
+- replace crate::Error with sacp::Error in dependent crates
+
+### Other
+
+- remove more uses of `agent_client_protocl_schema`
+- replace acp:: with crate::/sacp:: throughout codebase
+- rename JsonRpc* types to Jr* across all crates
+- *(deps)* switch from agent-client-protocol to agent-client-protocol-schema
+- prepare release-plz

--- a/src/sacp-conductor/Cargo.toml
+++ b/src/sacp-conductor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-conductor"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "Conductor for orchestrating SACP proxy chains"
 license = "MIT OR Apache-2.0"
@@ -12,8 +12,8 @@ categories = ["development-tools"]
 test-support = []
 
 [dependencies]
-sacp = { version = "0.1.0", path = "../sacp" }
-sacp-proxy = { version = "0.1.0", path = "../sacp-proxy" }
+sacp = { version = "0.1.1", path = "../sacp" }
+sacp-proxy = { version = "0.1.1", path = "../sacp-proxy" }
 agent-client-protocol-schema.workspace = true
 anyhow.workspace = true
 clap.workspace = true

--- a/src/sacp-proxy/CHANGELOG.md
+++ b/src/sacp-proxy/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/symposium-dev/symposium-acp/compare/sacp-proxy-v0.1.0...sacp-proxy-v0.1.1) - 2025-10-30
+
+### Fixed
+
+- replace crate::Error with sacp::Error in dependent crates
+
+### Other
+
+- remove more uses of `agent_client_protocl_schema`
+- replace acp:: with crate::/sacp:: throughout codebase
+- rename JsonRpc* types to Jr* across all crates
+- *(deps)* switch from agent-client-protocol to agent-client-protocol-schema

--- a/src/sacp-proxy/Cargo.toml
+++ b/src/sacp-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-proxy"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "Framework for building SACP proxy components"
 license = "MIT OR Apache-2.0"
@@ -14,7 +14,7 @@ futures.workspace = true
 fxhash.workspace = true
 jsonrpcmsg.workspace = true
 rmcp.workspace = true
-sacp = { version = "0.1.0", path = "../sacp" }
+sacp = { version = "0.1.1", path = "../sacp" }
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true

--- a/src/sacp/CHANGELOG.md
+++ b/src/sacp/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/symposium-dev/symposium-acp/compare/sacp-v0.1.0...sacp-v0.1.1) - 2025-10-30
+
+### Added
+
+- *(sacp)* re-export all agent-client-protocol-schema types
+
+### Fixed
+
+- replace crate::Error with sacp::Error in dependent crates
+
+### Other
+
+- remove more uses of `agent_client_protocl_schema`
+- replace acp:: with crate::/sacp:: throughout codebase
+- rename JsonRpc* types to Jr* across all crates
+- *(deps)* switch from agent-client-protocol to agent-client-protocol-schema
+- *(sacp)* add simple_agent example demonstrating JsonRpcConnection usage

--- a/src/sacp/Cargo.toml
+++ b/src/sacp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "Core protocol types and traits for SACP (Symposium's extensions to ACP)"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `sacp`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `sacp-proxy`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `sacp-conductor`: 0.1.0 -> 0.1.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `sacp`

<blockquote>

## [0.1.1](https://github.com/symposium-dev/symposium-acp/compare/sacp-v0.1.0...sacp-v0.1.1) - 2025-10-30

### Added

- *(sacp)* re-export all agent-client-protocol-schema types

### Fixed

- replace crate::Error with sacp::Error in dependent crates

### Other

- remove more uses of `agent_client_protocl_schema`
- replace acp:: with crate::/sacp:: throughout codebase
- rename JsonRpc* types to Jr* across all crates
- *(deps)* switch from agent-client-protocol to agent-client-protocol-schema
- *(sacp)* add simple_agent example demonstrating JsonRpcConnection usage
</blockquote>

## `sacp-proxy`

<blockquote>

## [0.1.1](https://github.com/symposium-dev/symposium-acp/compare/sacp-proxy-v0.1.0...sacp-proxy-v0.1.1) - 2025-10-30

### Fixed

- replace crate::Error with sacp::Error in dependent crates

### Other

- remove more uses of `agent_client_protocl_schema`
- replace acp:: with crate::/sacp:: throughout codebase
- rename JsonRpc* types to Jr* across all crates
- *(deps)* switch from agent-client-protocol to agent-client-protocol-schema
</blockquote>

## `sacp-conductor`

<blockquote>

## [0.1.1](https://github.com/symposium-dev/symposium-acp/compare/sacp-conductor-v0.1.0...sacp-conductor-v0.1.1) - 2025-10-30

### Fixed

- replace crate::Error with sacp::Error in dependent crates

### Other

- remove more uses of `agent_client_protocl_schema`
- replace acp:: with crate::/sacp:: throughout codebase
- rename JsonRpc* types to Jr* across all crates
- *(deps)* switch from agent-client-protocol to agent-client-protocol-schema
- prepare release-plz
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).