### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -850,7 +850,7 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "sacp"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "agent-client-protocol-schema",
  "anyhow",
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "sacp-conductor"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "agent-client-protocol-schema",
  "anyhow",
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "sacp-proxy"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "agent-client-protocol-schema",
  "chrono",

--- a/src/elizacp/Cargo.toml
+++ b/src/elizacp/Cargo.toml
@@ -15,7 +15,7 @@ name = "elizacp"
 path = "src/main.rs"
 
 [dependencies]
-sacp = { version = "0.1.0", path = "../sacp" }
+sacp = { version = "0.2.0", path = "../sacp" }
 agent-client-protocol-schema.workspace = true
 anyhow.workspace = true
 clap.workspace = true

--- a/src/sacp-conductor/CHANGELOG.md
+++ b/src/sacp-conductor/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-conductor-v0.1.1...sacp-conductor-v0.2.0) - 2025-11-04
+
+### Fixed
+
+- fix github url
+
+### Other
+
+- *(sacp-conductor)* add comprehensive crate-level documentation
+- *(sacp)* [**breaking**] rename json_rpc_cx to connection_cx
+- rename JsonRpcRequest to JrRequest
+- add READMEs for sacp-tokio, sacp-proxy, and sacp-conductor
+
 ## [0.1.1](https://github.com/symposium-dev/symposium-acp/compare/sacp-conductor-v0.1.0...sacp-conductor-v0.1.1) - 2025-10-30
 
 ### Fixed

--- a/src/sacp-conductor/Cargo.toml
+++ b/src/sacp-conductor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-conductor"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2024"
 description = "Conductor for orchestrating SACP proxy chains"
 license = "MIT OR Apache-2.0"
@@ -12,8 +12,8 @@ categories = ["development-tools"]
 test-support = []
 
 [dependencies]
-sacp = { version = "0.1.1", path = "../sacp" }
-sacp-proxy = { version = "0.1.1", path = "../sacp-proxy" }
+sacp = { version = "0.2.0", path = "../sacp" }
+sacp-proxy = { version = "0.1.2", path = "../sacp-proxy" }
 agent-client-protocol-schema.workspace = true
 anyhow.workspace = true
 clap.workspace = true

--- a/src/sacp-doc-test/CHANGELOG.md
+++ b/src/sacp-doc-test/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-doc-test-v0.1.0) - 2025-11-04
+
+### Other
+
+- factor "doc-test-only" code into its own crate

--- a/src/sacp-proxy/CHANGELOG.md
+++ b/src/sacp-proxy/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/symposium-dev/symposium-acp/compare/sacp-proxy-v0.1.1...sacp-proxy-v0.1.2) - 2025-11-04
+
+### Fixed
+
+- fix github url
+
+### Other
+
+- add GitHub links to example files in sacp and sacp-proxy
+- add deny(missing_docs) and document all public APIs
+- *(sacp-proxy)* add comprehensive crate-level documentation
+- rename JsonRpcRequest to JrRequest
+- add READMEs for sacp-tokio, sacp-proxy, and sacp-conductor
+
 ## [0.1.1](https://github.com/symposium-dev/symposium-acp/compare/sacp-proxy-v0.1.0...sacp-proxy-v0.1.1) - 2025-10-30
 
 ### Fixed

--- a/src/sacp-proxy/Cargo.toml
+++ b/src/sacp-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-proxy"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 description = "Framework for building SACP proxy components"
 license = "MIT OR Apache-2.0"
@@ -14,7 +14,7 @@ futures.workspace = true
 fxhash.workspace = true
 jsonrpcmsg.workspace = true
 rmcp.workspace = true
-sacp = { version = "0.1.1", path = "../sacp" }
+sacp = { version = "0.2.0", path = "../sacp" }
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true

--- a/src/sacp-tokio/CHANGELOG.md
+++ b/src/sacp-tokio/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-tokio-v0.1.1) - 2025-11-04
+
+### Added
+
+- *(sacp-tokio)* implement JrConnectionExt trait for to_agent
+- create sacp-tokio crate and improve AcpAgent API
+
+### Fixed
+
+- fix github url
+
+### Other
+
+- add READMEs for sacp-tokio, sacp-proxy, and sacp-conductor

--- a/src/sacp-tokio/Cargo.toml
+++ b/src/sacp-tokio/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["acp", "agent", "protocol", "ai", "tokio"]
 categories = ["development-tools"]
 
 [dependencies]
-sacp = { version = "0.1.1", path = "../sacp" }
+sacp = { version = "0.2.0", path = "../sacp" }
 futures.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/src/sacp/CHANGELOG.md
+++ b/src/sacp/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-v0.1.1...sacp-v0.2.0) - 2025-11-04
+
+### Added
+
+- *(sacp-tokio)* implement JrConnectionExt trait for to_agent
+- create sacp-tokio crate and improve AcpAgent API
+- *(sacp)* add AcpAgent utility and yolo-one-shot-client example
+
+### Fixed
+
+- fix github url
+
+### Other
+
+- add GitHub links to example files in sacp and sacp-proxy
+- *(sacp)* [**breaking**] rename json_rpc_cx to connection_cx
+- add deny(missing_docs) and document all public APIs
+- *(sacp)* improve cx cloning pattern in doc examples
+- *(sacp)* update crate-level documentation to match README
+- factor "doc-test-only" code into its own crate
+- make doctests build
+- *(sacp)* fix remaining doc test compilation errors
+- *(sacp)* enhance JrResponse method documentation
+- *(sacp)* document event loop and concurrency model
+- rename JsonRpcRequest to JrRequest
+- use util.rs
+- *(sacp)* move typed utilities to util module and add docs
+- *(sacp)* remove mention of non-existent derive macro
+- *(sacp)* fix doctests to compile instead of being ignored
+- *(sacp)* add comprehensive rustdoc for JrConnection
+- *(sacp)* rewrite README with streamlined quick start
+- *(sacp)* use stderr for yolo-one-shot-client meta output
+
 ## [0.1.1](https://github.com/symposium-dev/symposium-acp/compare/sacp-v0.1.0...sacp-v0.1.1) - 2025-10-30
 
 ### Added

--- a/src/sacp/Cargo.toml
+++ b/src/sacp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2024"
 description = "Core protocol types and traits for SACP (Symposium's extensions to ACP)"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `sacp`: 0.1.1 -> 0.2.0 (✓ API compatible changes)
* `sacp-proxy`: 0.1.1 -> 0.1.2 (✓ API compatible changes)
* `sacp-doc-test`: 0.1.0
* `sacp-tokio`: 0.1.1
* `sacp-conductor`: 0.1.1 -> 0.2.0 (✓ API compatible changes)
* `elizacp`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `sacp`

<blockquote>

## [0.2.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-v0.1.1...sacp-v0.2.0) - 2025-11-04

### Added

- *(sacp-tokio)* implement JrConnectionExt trait for to_agent
- create sacp-tokio crate and improve AcpAgent API
- *(sacp)* add AcpAgent utility and yolo-one-shot-client example

### Fixed

- fix github url

### Other

- add GitHub links to example files in sacp and sacp-proxy
- *(sacp)* [**breaking**] rename json_rpc_cx to connection_cx
- add deny(missing_docs) and document all public APIs
- *(sacp)* improve cx cloning pattern in doc examples
- *(sacp)* update crate-level documentation to match README
- factor "doc-test-only" code into its own crate
- make doctests build
- *(sacp)* fix remaining doc test compilation errors
- *(sacp)* enhance JrResponse method documentation
- *(sacp)* document event loop and concurrency model
- rename JsonRpcRequest to JrRequest
- use util.rs
- *(sacp)* move typed utilities to util module and add docs
- *(sacp)* remove mention of non-existent derive macro
- *(sacp)* fix doctests to compile instead of being ignored
- *(sacp)* add comprehensive rustdoc for JrConnection
- *(sacp)* rewrite README with streamlined quick start
- *(sacp)* use stderr for yolo-one-shot-client meta output
</blockquote>

## `sacp-proxy`

<blockquote>

## [0.1.2](https://github.com/symposium-dev/symposium-acp/compare/sacp-proxy-v0.1.1...sacp-proxy-v0.1.2) - 2025-11-04

### Fixed

- fix github url

### Other

- add GitHub links to example files in sacp and sacp-proxy
- add deny(missing_docs) and document all public APIs
- *(sacp-proxy)* add comprehensive crate-level documentation
- rename JsonRpcRequest to JrRequest
- add READMEs for sacp-tokio, sacp-proxy, and sacp-conductor
</blockquote>

## `sacp-doc-test`

<blockquote>

## [0.1.0](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-doc-test-v0.1.0) - 2025-11-04

### Other

- factor "doc-test-only" code into its own crate
</blockquote>

## `sacp-tokio`

<blockquote>

## [0.1.1](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-tokio-v0.1.1) - 2025-11-04

### Added

- *(sacp-tokio)* implement JrConnectionExt trait for to_agent
- create sacp-tokio crate and improve AcpAgent API

### Fixed

- fix github url

### Other

- add READMEs for sacp-tokio, sacp-proxy, and sacp-conductor
</blockquote>

## `sacp-conductor`

<blockquote>

## [0.2.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-conductor-v0.1.1...sacp-conductor-v0.2.0) - 2025-11-04

### Fixed

- fix github url

### Other

- *(sacp-conductor)* add comprehensive crate-level documentation
- *(sacp)* [**breaking**] rename json_rpc_cx to connection_cx
- rename JsonRpcRequest to JrRequest
- add READMEs for sacp-tokio, sacp-proxy, and sacp-conductor
</blockquote>

## `elizacp`

<blockquote>

## [0.1.0](https://github.com/symposium-dev/symposium-acp/releases/tag/elizacp-v0.1.0) - 2025-10-31

### Added

- *(elizacp)* add Eliza chatbot as ACP agent for testing

### Fixed

- *(elizacp)* exclude punctuation from pattern captures

### Other

- *(elizacp)* prepare for crates.io publication
- cleanup the source to make it prettier as an example
- *(elizacp)* use expect_test for exact output verification
- *(elizacp)* use seeded RNG for deterministic responses
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).