### PR TITLE
chore: release v1.0.0-alpha

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -802,9 +802,9 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "rmcp"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fdad1258f7259fdc0f2dfc266939c82c3b5d1fd72bcde274d600cdc27e60243"
+checksum = "a2c66318b30535ccd0d3b39afaa4240d6b5a35328fb7672a28e3386c97472805"
 dependencies = [
  "base64",
  "chrono",
@@ -825,9 +825,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ede0589a208cc7ce81d1be68aa7e74b917fcd03c81528408bab0457e187dcd9b"
+checksum = "49a19193e0d69bb1c96324b1b4daec078d4c8e76d734e53404c107437858a4d2"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/src/elizacp/CHANGELOG.md
+++ b/src/elizacp/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-alpha](https://github.com/symposium-dev/symposium-acp/releases/tag/elizacp-v1.0.0-alpha) - 2025-11-05
+
+### Added
+
+- *(elizacp)* add Eliza chatbot as ACP agent for testing
+
+### Fixed
+
+- fix github url
+- *(elizacp)* exclude punctuation from pattern captures
+
+### Other
+
+- *(conductor)* add mock component tests for nested conductors
+- bump all packages to version 1.0.0-alpha
+- *(sacp)* [**breaking**] reorganize modules with flat schema namespace
+- release
+- *(elizacp)* add module-level documentation to main.rs
+- upgrade to latest version of depdencies
+- *(elizacp)* release v0.1.0
+- *(elizacp)* prepare for crates.io publication
+- cleanup the source to make it prettier as an example
+- *(elizacp)* use expect_test for exact output verification
+- *(elizacp)* use seeded RNG for deterministic responses
+
 ## [0.1.0](https://github.com/symposium-dev/symposium-acp/releases/tag/elizacp-v0.1.0) - 2025-10-31
 
 ### Added

--- a/src/sacp-test/CHANGELOG.md
+++ b/src/sacp-test/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-alpha](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-test-v1.0.0-alpha) - 2025-11-05
+
+### Added
+
+- *(sacp-test)* add arrow proxy for testing
+
+### Other
+
+- *(conductor)* add integration test with arrow proxy and eliza
+- *(conductor)* add integration test with arrow proxy and eliza
+- rename sacp-doc-test to sacp-test
+
 ## [0.1.0](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-doc-test-v0.1.0) - 2025-11-04
 
 ### Other

--- a/src/sacp-tokio/CHANGELOG.md
+++ b/src/sacp-tokio/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-alpha](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-tokio-v1.0.0-alpha) - 2025-11-05
+
+### Added
+
+- *(conductor)* add proxy mode support for hierarchical chains
+- *(sacp-tokio)* implement JrConnectionExt trait for to_agent
+- create sacp-tokio crate and improve AcpAgent API
+
+### Fixed
+
+- *(sacp-tokio)* correct type path in doctest example
+- fix github url
+
+### Other
+
+- bump all packages to version 1.0.0-alpha
+- *(sacp)* move handler types to dedicated handler module
+- *(sacp)* [**breaking**] reorganize modules with flat schema namespace
+- release
+- add READMEs for sacp-tokio, sacp-proxy, and sacp-conductor
+
 ## [0.1.1](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-tokio-v0.1.1) - 2025-11-04
 
 ### Added


### PR DESCRIPTION



## 🤖 New release

* `sacp-test`: 1.0.0-alpha
* `sacp-tokio`: 1.0.0-alpha
* `elizacp`: 1.0.0-alpha

<details><summary><i><b>Changelog</b></i></summary><p>

## `sacp-test`

<blockquote>

## [1.0.0-alpha](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-test-v1.0.0-alpha) - 2025-11-05

### Added

- *(sacp-test)* add arrow proxy for testing

### Other

- *(conductor)* add integration test with arrow proxy and eliza
- *(conductor)* add integration test with arrow proxy and eliza
- rename sacp-doc-test to sacp-test
</blockquote>

## `sacp-tokio`

<blockquote>

## [1.0.0-alpha](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-tokio-v1.0.0-alpha) - 2025-11-05

### Added

- *(conductor)* add proxy mode support for hierarchical chains
- *(sacp-tokio)* implement JrConnectionExt trait for to_agent
- create sacp-tokio crate and improve AcpAgent API

### Fixed

- *(sacp-tokio)* correct type path in doctest example
- fix github url

### Other

- bump all packages to version 1.0.0-alpha
- *(sacp)* move handler types to dedicated handler module
- *(sacp)* [**breaking**] reorganize modules with flat schema namespace
- release
- add READMEs for sacp-tokio, sacp-proxy, and sacp-conductor
</blockquote>

## `elizacp`

<blockquote>

## [1.0.0-alpha](https://github.com/symposium-dev/symposium-acp/releases/tag/elizacp-v1.0.0-alpha) - 2025-11-05

### Added

- *(elizacp)* add Eliza chatbot as ACP agent for testing

### Fixed

- fix github url
- *(elizacp)* exclude punctuation from pattern captures

### Other

- *(conductor)* add mock component tests for nested conductors
- bump all packages to version 1.0.0-alpha
- *(sacp)* [**breaking**] reorganize modules with flat schema namespace
- release
- *(elizacp)* add module-level documentation to main.rs
- upgrade to latest version of depdencies
- *(elizacp)* release v0.1.0
- *(elizacp)* prepare for crates.io publication
- cleanup the source to make it prettier as an example
- *(elizacp)* use expect_test for exact output verification
- *(elizacp)* use seeded RNG for deterministic responses
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).