### PR TITLE
chore: update all versions from 1.0.0-alpha to 1.0.0-alpha.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,7 +289,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "elizacp"
-version = "1.0.0-alpha"
+version = "1.0.0-alpha.1"
 dependencies = [
  "agent-client-protocol-schema",
  "anyhow",
@@ -850,7 +850,7 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "sacp"
-version = "1.0.0-alpha"
+version = "1.0.0-alpha.1"
 dependencies = [
  "agent-client-protocol-schema",
  "anyhow",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "sacp-conductor"
-version = "1.0.0-alpha"
+version = "1.0.0-alpha.1"
 dependencies = [
  "agent-client-protocol-schema",
  "anyhow",
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "sacp-proxy"
-version = "1.0.0-alpha"
+version = "1.0.0-alpha.1"
 dependencies = [
  "agent-client-protocol-schema",
  "chrono",
@@ -921,7 +921,7 @@ dependencies = [
 
 [[package]]
 name = "sacp-test"
-version = "1.0.0-alpha"
+version = "1.0.0-alpha.1"
 dependencies = [
  "futures",
  "sacp",
@@ -936,7 +936,7 @@ dependencies = [
 
 [[package]]
 name = "sacp-tokio"
-version = "1.0.0-alpha"
+version = "1.0.0-alpha.1"
 dependencies = [
  "expect-test",
  "futures",
@@ -1593,7 +1593,7 @@ checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "yopo"
-version = "1.0.0-alpha"
+version = "1.0.0-alpha.1"
 dependencies = [
  "sacp",
  "sacp-tokio",

--- a/src/elizacp/Cargo.toml
+++ b/src/elizacp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elizacp"
-version = "1.0.0-alpha"
+version = "1.0.0-alpha.1"
 edition = "2024"
 description = "Classic Eliza chatbot as an ACP agent for testing"
 license = "MIT OR Apache-2.0"
@@ -15,7 +15,7 @@ name = "elizacp"
 path = "src/main.rs"
 
 [dependencies]
-sacp = { version = "1.0.0-alpha", path = "../sacp" }
+sacp = { version = "1.0.0-alpha.1", path = "../sacp" }
 agent-client-protocol-schema.workspace = true
 anyhow.workspace = true
 clap.workspace = true

--- a/src/sacp-conductor/Cargo.toml
+++ b/src/sacp-conductor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-conductor"
-version = "1.0.0-alpha"
+version = "1.0.0-alpha.1"
 edition = "2024"
 description = "Conductor for orchestrating SACP proxy chains"
 license = "MIT OR Apache-2.0"
@@ -12,9 +12,9 @@ categories = ["development-tools"]
 test-support = []
 
 [dependencies]
-sacp = { version = "1.0.0-alpha", path = "../sacp" }
-sacp-proxy = { version = "1.0.0-alpha", path = "../sacp-proxy" }
-sacp-tokio = { version = "1.0.0-alpha", path = "../sacp-tokio" }
+sacp = { version = "1.0.0-alpha.1", path = "../sacp" }
+sacp-proxy = { version = "1.0.0-alpha.1", path = "../sacp-proxy" }
+sacp-tokio = { version = "1.0.0-alpha.1", path = "../sacp-tokio" }
 agent-client-protocol-schema.workspace = true
 anyhow.workspace = true
 clap.workspace = true

--- a/src/sacp-proxy/Cargo.toml
+++ b/src/sacp-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-proxy"
-version = "1.0.0-alpha"
+version = "1.0.0-alpha.1"
 edition = "2024"
 description = "Framework for building SACP proxy components"
 license = "MIT OR Apache-2.0"
@@ -14,7 +14,7 @@ futures.workspace = true
 fxhash.workspace = true
 jsonrpcmsg.workspace = true
 rmcp.workspace = true
-sacp = { version = "1.0.0-alpha", path = "../sacp" }
+sacp = { version = "1.0.0-alpha.1", path = "../sacp" }
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true

--- a/src/sacp-test/Cargo.toml
+++ b/src/sacp-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-test"
-version = "1.0.0-alpha"
+version = "1.0.0-alpha.1"
 edition = "2024"
 
 [dependencies]

--- a/src/sacp-tokio/Cargo.toml
+++ b/src/sacp-tokio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-tokio"
-version = "1.0.0-alpha"
+version = "1.0.0-alpha.1"
 edition = "2024"
 description = "Tokio-based utilities for SACP (Symposium's extensions to ACP)"
 license = "MIT OR Apache-2.0"
@@ -9,7 +9,7 @@ keywords = ["acp", "agent", "protocol", "ai", "tokio"]
 categories = ["development-tools"]
 
 [dependencies]
-sacp = { version = "1.0.0-alpha", path = "../sacp" }
+sacp = { version = "1.0.0-alpha.1", path = "../sacp" }
 futures.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/src/sacp/Cargo.toml
+++ b/src/sacp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp"
-version = "1.0.0-alpha"
+version = "1.0.0-alpha.1"
 edition = "2024"
 description = "Core protocol types and traits for SACP (Symposium's extensions to ACP)"
 license = "MIT OR Apache-2.0"

--- a/src/yopo/Cargo.toml
+++ b/src/yopo/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "yopo"
-version = "1.0.0-alpha"
+version = "1.0.0-alpha.1"
 edition = "2024"
 description = "YOPO (You Only Prompt Once) - A simple ACP client for one-shot prompts"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/symposium-dev/symposium-acp"
 
 [dependencies]
-sacp = { version = "1.0.0-alpha", path = "../sacp" }
-sacp-tokio = { version = "1.0.0-alpha", path = "../sacp-tokio" }
+sacp = { version = "1.0.0-alpha.1", path = "../sacp" }
+sacp-tokio = { version = "1.0.0-alpha.1", path = "../sacp-tokio" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }


### PR DESCRIPTION
Use the standard semver prerelease format with a dot separator (1.0.0-alpha.1) instead of 1.0.0-alpha for all crates.