### PR TITLE
chore: release v1.0.0-alpha.1

### DIFF
--- a/src/elizacp/CHANGELOG.md
+++ b/src/elizacp/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-alpha.1](https://github.com/symposium-dev/symposium-acp/releases/tag/elizacp-v1.0.0-alpha.1) - 2025-11-05
+
+### Added
+
+- *(elizacp)* add Eliza chatbot as ACP agent for testing
+
+### Fixed
+
+- fix github url
+- *(elizacp)* exclude punctuation from pattern captures
+
+### Other
+
+- update all versions from 1.0.0-alpha to 1.0.0-alpha.1
+- release v1.0.0-alpha
+- *(conductor)* add mock component tests for nested conductors
+- bump all packages to version 1.0.0-alpha
+- *(sacp)* [**breaking**] reorganize modules with flat schema namespace
+- release
+- *(elizacp)* add module-level documentation to main.rs
+- upgrade to latest version of depdencies
+- *(elizacp)* release v0.1.0
+- *(elizacp)* prepare for crates.io publication
+- cleanup the source to make it prettier as an example
+- *(elizacp)* use expect_test for exact output verification
+- *(elizacp)* use seeded RNG for deterministic responses
+
 ## [1.0.0-alpha](https://github.com/symposium-dev/symposium-acp/releases/tag/elizacp-v1.0.0-alpha) - 2025-11-05
 
 ### Added

--- a/src/sacp-test/CHANGELOG.md
+++ b/src/sacp-test/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-alpha.1](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-test-v1.0.0-alpha.1) - 2025-11-05
+
+### Added
+
+- *(sacp-test)* add arrow proxy for testing
+
+### Other
+
+- update all versions from 1.0.0-alpha to 1.0.0-alpha.1
+- release v1.0.0-alpha
+- *(conductor)* add integration test with arrow proxy and eliza
+- *(conductor)* add integration test with arrow proxy and eliza
+- rename sacp-doc-test to sacp-test
+
 ## [1.0.0-alpha](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-test-v1.0.0-alpha) - 2025-11-05
 
 ### Added

--- a/src/yopo/CHANGELOG.md
+++ b/src/yopo/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-alpha.1](https://github.com/symposium-dev/symposium-acp/releases/tag/yopo-v1.0.0-alpha.1) - 2025-11-05
+
+### Added
+
+- *(yopo)* add yopo binary crate and simplify example
+
+### Other
+
+- Merge pull request #14 from nikomatsakis/main
+- update all versions from 1.0.0-alpha to 1.0.0-alpha.1
+
 ## [1.0.0-alpha](https://github.com/symposium-dev/symposium-acp/releases/tag/yopo-v1.0.0-alpha) - 2025-11-05
 
 ### Added


### PR DESCRIPTION



## 🤖 New release

* `sacp-test`: 1.0.0-alpha.1
* `elizacp`: 1.0.0-alpha.1
* `yopo`: 1.0.0-alpha.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `sacp-test`

<blockquote>

## [1.0.0-alpha.1](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-test-v1.0.0-alpha.1) - 2025-11-05

### Added

- *(sacp-test)* add arrow proxy for testing

### Other

- update all versions from 1.0.0-alpha to 1.0.0-alpha.1
- release v1.0.0-alpha
- *(conductor)* add integration test with arrow proxy and eliza
- *(conductor)* add integration test with arrow proxy and eliza
- rename sacp-doc-test to sacp-test
</blockquote>

## `elizacp`

<blockquote>

## [1.0.0-alpha.1](https://github.com/symposium-dev/symposium-acp/releases/tag/elizacp-v1.0.0-alpha.1) - 2025-11-05

### Added

- *(elizacp)* add Eliza chatbot as ACP agent for testing

### Fixed

- fix github url
- *(elizacp)* exclude punctuation from pattern captures

### Other

- update all versions from 1.0.0-alpha to 1.0.0-alpha.1
- release v1.0.0-alpha
- *(conductor)* add mock component tests for nested conductors
- bump all packages to version 1.0.0-alpha
- *(sacp)* [**breaking**] reorganize modules with flat schema namespace
- release
- *(elizacp)* add module-level documentation to main.rs
- upgrade to latest version of depdencies
- *(elizacp)* release v0.1.0
- *(elizacp)* prepare for crates.io publication
- cleanup the source to make it prettier as an example
- *(elizacp)* use expect_test for exact output verification
- *(elizacp)* use seeded RNG for deterministic responses
</blockquote>

## `yopo`

<blockquote>

## [1.0.0-alpha.1](https://github.com/symposium-dev/symposium-acp/releases/tag/yopo-v1.0.0-alpha.1) - 2025-11-05

### Added

- *(yopo)* add yopo binary crate and simplify example

### Other

- Merge pull request #14 from nikomatsakis/main
- update all versions from 1.0.0-alpha to 1.0.0-alpha.1
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).