### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,9 +133,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.44"
+version = "1.2.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37521ac7aabe3d13122dc382493e20c9416f299d2ccd5b3a5340a2570cdeb0f3"
+checksum = "35900b6c8d709fb1d854671ae27aeaa9eec2f8b01b364e1619a40da3e6fe2afe"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -289,7 +289,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "elizacp"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha.2"
 dependencies = [
  "agent-client-protocol-schema",
  "anyhow",
@@ -700,9 +700,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.41"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
+checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
 dependencies = [
  "proc-macro2",
 ]
@@ -802,9 +802,9 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "rmcp"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2c66318b30535ccd0d3b39afaa4240d6b5a35328fb7672a28e3386c97472805"
+checksum = "e5947688160b56fb6c827e3c20a72c90392a1d7e9dec74749197aa1780ac42ca"
 dependencies = [
  "base64",
  "chrono",
@@ -825,9 +825,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49a19193e0d69bb1c96324b1b4daec078d4c8e76d734e53404c107437858a4d2"
+checksum = "01263441d3f8635c628e33856c468b96ebbce1af2d3699ea712ca71432d4ee7a"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -850,7 +850,7 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "sacp"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha.2"
 dependencies = [
  "agent-client-protocol-schema",
  "anyhow",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "sacp-conductor"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha.2"
 dependencies = [
  "agent-client-protocol-schema",
  "anyhow",
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "sacp-proxy"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha.2"
 dependencies = [
  "agent-client-protocol-schema",
  "chrono",
@@ -937,7 +937,7 @@ dependencies = [
 
 [[package]]
 name = "sacp-tokio"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha.2"
 dependencies = [
  "expect-test",
  "futures",
@@ -952,9 +952,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.0.5"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1317c3bf3e7df961da95b0a56a172a02abead31276215a0497241a7624b487ce"
+checksum = "9558e172d4e8533736ba97870c4b2cd63f84b382a3d6eb063da41b91cce17289"
 dependencies = [
  "chrono",
  "dyn-clone",
@@ -966,9 +966,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "1.0.5"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f760a6150d45dd66ec044983c124595ae76912e77ed0b44124cb3e415cce5d9"
+checksum = "301858a4023d78debd2353c7426dc486001bddc91ae31a76fb1f55132f7e2633"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1096,9 +1096,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.108"
+version = "2.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da58917d35242480a05c2897064da0a80589a2a0476c9a3f2fdc83b53502e917"
+checksum = "2f17c7e013e88258aa9543dcbe81aca68a667a9ac37cd69c9fbc07858bfe0e2f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1595,7 +1595,7 @@ checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "yopo"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha.2"
 dependencies = [
  "sacp",
  "sacp-tokio",

--- a/src/elizacp/CHANGELOG.md
+++ b/src/elizacp/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-alpha.2](https://github.com/symposium-dev/symposium-acp/compare/elizacp-v1.0.0-alpha.1...elizacp-v1.0.0-alpha.2) - 2025-11-08
+
+### Other
+
+- Merge pull request #16 from nikomatsakis/main
+- wip wip wip
+- [**breaking**] remove Unpin bounds and simplify transport API
+
 ## [1.0.0-alpha.1](https://github.com/symposium-dev/symposium-acp/releases/tag/elizacp-v1.0.0-alpha.1) - 2025-11-05
 
 ### Added

--- a/src/elizacp/Cargo.toml
+++ b/src/elizacp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elizacp"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha.2"
 edition = "2024"
 description = "Classic Eliza chatbot as an ACP agent for testing"
 license = "MIT OR Apache-2.0"
@@ -15,7 +15,7 @@ name = "elizacp"
 path = "src/main.rs"
 
 [dependencies]
-sacp = { version = "1.0.0-alpha.1", path = "../sacp" }
+sacp = { version = "1.0.0-alpha.2", path = "../sacp" }
 agent-client-protocol-schema.workspace = true
 anyhow.workspace = true
 clap.workspace = true

--- a/src/sacp-conductor/CHANGELOG.md
+++ b/src/sacp-conductor/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-alpha.2](https://github.com/symposium-dev/symposium-acp/compare/sacp-conductor-v1.0.0-alpha.1...sacp-conductor-v1.0.0-alpha.2) - 2025-11-08
+
+### Added
+
+- *(sacp)* add convenience methods for common connection patterns
+
+### Other
+
+- fix doctests for API refactoring
+- wip wip wip
+- wipwipwip
+- [**breaking**] remove Unpin bounds and simplify transport API
+
 ## [0.2.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-conductor-v0.1.1...sacp-conductor-v0.2.0) - 2025-11-04
 
 ### Fixed

--- a/src/sacp-conductor/Cargo.toml
+++ b/src/sacp-conductor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-conductor"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha.2"
 edition = "2024"
 description = "Conductor for orchestrating SACP proxy chains"
 license = "MIT OR Apache-2.0"
@@ -12,9 +12,9 @@ categories = ["development-tools"]
 test-support = []
 
 [dependencies]
-sacp = { version = "1.0.0-alpha.1", path = "../sacp" }
-sacp-proxy = { version = "1.0.0-alpha.1", path = "../sacp-proxy" }
-sacp-tokio = { version = "1.0.0-alpha.1", path = "../sacp-tokio" }
+sacp = { version = "1.0.0-alpha.2", path = "../sacp" }
+sacp-proxy = { version = "1.0.0-alpha.2", path = "../sacp-proxy" }
+sacp-tokio = { version = "1.0.0-alpha.2", path = "../sacp-tokio" }
 agent-client-protocol-schema.workspace = true
 anyhow.workspace = true
 clap.workspace = true

--- a/src/sacp-proxy/CHANGELOG.md
+++ b/src/sacp-proxy/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-alpha.2](https://github.com/symposium-dev/symposium-acp/compare/sacp-proxy-v1.0.0-alpha.1...sacp-proxy-v1.0.0-alpha.2) - 2025-11-08
+
+### Other
+
+- fix doctests for API refactoring
+- wip wip wip
+- wipwipwip
+- introduce a `IntoJrHandler` trait
+- [**breaking**] remove Unpin bounds and simplify transport API
+
 ## [0.1.2](https://github.com/symposium-dev/symposium-acp/compare/sacp-proxy-v0.1.1...sacp-proxy-v0.1.2) - 2025-11-04
 
 ### Fixed

--- a/src/sacp-proxy/Cargo.toml
+++ b/src/sacp-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-proxy"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha.2"
 edition = "2024"
 description = "Framework for building SACP proxy components"
 license = "MIT OR Apache-2.0"
@@ -14,7 +14,7 @@ futures.workspace = true
 fxhash.workspace = true
 jsonrpcmsg.workspace = true
 rmcp.workspace = true
-sacp = { version = "1.0.0-alpha.1", path = "../sacp" }
+sacp = { version = "1.0.0-alpha.2", path = "../sacp" }
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true

--- a/src/sacp-tokio/CHANGELOG.md
+++ b/src/sacp-tokio/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-alpha.2](https://github.com/symposium-dev/symposium-acp/compare/sacp-tokio-v1.0.0-alpha.1...sacp-tokio-v1.0.0-alpha.2) - 2025-11-08
+
+### Other
+
+- fix doctests for API refactoring
+- wip wip wip
+- [**breaking**] remove Unpin bounds and simplify transport API
+
 ## [1.0.0-alpha](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-tokio-v1.0.0-alpha) - 2025-11-05
 
 ### Added

--- a/src/sacp-tokio/Cargo.toml
+++ b/src/sacp-tokio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-tokio"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha.2"
 edition = "2024"
 description = "Tokio-based utilities for SACP (Symposium's extensions to ACP)"
 license = "MIT OR Apache-2.0"
@@ -9,7 +9,7 @@ keywords = ["acp", "agent", "protocol", "ai", "tokio"]
 categories = ["development-tools"]
 
 [dependencies]
-sacp = { version = "1.0.0-alpha.1", path = "../sacp" }
+sacp = { version = "1.0.0-alpha.2", path = "../sacp" }
 futures.workspace = true
 jsonrpcmsg.workspace = true
 serde.workspace = true

--- a/src/sacp/CHANGELOG.md
+++ b/src/sacp/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-alpha.2](https://github.com/symposium-dev/symposium-acp/compare/sacp-v1.0.0-alpha.1...sacp-v1.0.0-alpha.2) - 2025-11-08
+
+### Added
+
+- *(sacp)* add convenience methods for common connection patterns
+- *(sacp)* add IntoJrConnectionTransport trait and ByteStreamTransport
+
+### Other
+
+- fix doctests for API refactoring
+- wip wip wip
+- wipwipwip
+- introduce a `IntoJrHandler` trait
+- [**breaking**] remove Unpin bounds and simplify transport API
+- *(sacp)* clarify id: None semantics and remove phase references
+- *(sacp)* split actors into protocol and transport layers
+
 ## [0.2.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-v0.1.1...sacp-v0.2.0) - 2025-11-04
 
 ### Added

--- a/src/sacp/Cargo.toml
+++ b/src/sacp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha.2"
 edition = "2024"
 description = "Core protocol types and traits for SACP (Symposium's extensions to ACP)"
 license = "MIT OR Apache-2.0"

--- a/src/yopo/CHANGELOG.md
+++ b/src/yopo/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-alpha.2](https://github.com/symposium-dev/symposium-acp/compare/yopo-v1.0.0-alpha.1...yopo-v1.0.0-alpha.2) - 2025-11-08
+
+### Other
+
+- Merge pull request #16 from nikomatsakis/main
+- wip wip wip
+- [**breaking**] remove Unpin bounds and simplify transport API
+
 ## [1.0.0-alpha.1](https://github.com/symposium-dev/symposium-acp/releases/tag/yopo-v1.0.0-alpha.1) - 2025-11-05
 
 ### Added

--- a/src/yopo/Cargo.toml
+++ b/src/yopo/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "yopo"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha.2"
 edition = "2024"
 description = "YOPO (You Only Prompt Once) - A simple ACP client for one-shot prompts"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/symposium-dev/symposium-acp"
 
 [dependencies]
-sacp = { version = "1.0.0-alpha.1", path = "../sacp" }
-sacp-tokio = { version = "1.0.0-alpha.1", path = "../sacp-tokio" }
+sacp = { version = "1.0.0-alpha.2", path = "../sacp" }
+sacp-tokio = { version = "1.0.0-alpha.2", path = "../sacp-tokio" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }


### PR DESCRIPTION



## 🤖 New release

* `sacp`: 1.0.0-alpha.1 -> 1.0.0-alpha.2 (✓ API compatible changes)
* `sacp-proxy`: 1.0.0-alpha.1 -> 1.0.0-alpha.2 (✓ API compatible changes)
* `sacp-test`: 1.0.0-alpha.1
* `sacp-tokio`: 1.0.0-alpha.1 -> 1.0.0-alpha.2 (✓ API compatible changes)
* `sacp-conductor`: 1.0.0-alpha.1 -> 1.0.0-alpha.2 (✓ API compatible changes)
* `elizacp`: 1.0.0-alpha.1 -> 1.0.0-alpha.2 (✓ API compatible changes)
* `yopo`: 1.0.0-alpha.1 -> 1.0.0-alpha.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `sacp`

<blockquote>

## [1.0.0-alpha.2](https://github.com/symposium-dev/symposium-acp/compare/sacp-v1.0.0-alpha.1...sacp-v1.0.0-alpha.2) - 2025-11-08

### Added

- *(sacp)* add convenience methods for common connection patterns
- *(sacp)* add IntoJrConnectionTransport trait and ByteStreamTransport

### Other

- fix doctests for API refactoring
- wip wip wip
- wipwipwip
- introduce a `IntoJrHandler` trait
- [**breaking**] remove Unpin bounds and simplify transport API
- *(sacp)* clarify id: None semantics and remove phase references
- *(sacp)* split actors into protocol and transport layers
</blockquote>

## `sacp-proxy`

<blockquote>

## [1.0.0-alpha.2](https://github.com/symposium-dev/symposium-acp/compare/sacp-proxy-v1.0.0-alpha.1...sacp-proxy-v1.0.0-alpha.2) - 2025-11-08

### Other

- fix doctests for API refactoring
- wip wip wip
- wipwipwip
- introduce a `IntoJrHandler` trait
- [**breaking**] remove Unpin bounds and simplify transport API
</blockquote>

## `sacp-test`

<blockquote>

## [1.0.0-alpha.1](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-test-v1.0.0-alpha.1) - 2025-11-05

### Added

- *(sacp-test)* add arrow proxy for testing

### Other

- update all versions from 1.0.0-alpha to 1.0.0-alpha.1
- release v1.0.0-alpha
- *(conductor)* add integration test with arrow proxy and eliza
- *(conductor)* add integration test with arrow proxy and eliza
- rename sacp-doc-test to sacp-test
</blockquote>

## `sacp-tokio`

<blockquote>

## [1.0.0-alpha.2](https://github.com/symposium-dev/symposium-acp/compare/sacp-tokio-v1.0.0-alpha.1...sacp-tokio-v1.0.0-alpha.2) - 2025-11-08

### Other

- fix doctests for API refactoring
- wip wip wip
- [**breaking**] remove Unpin bounds and simplify transport API
</blockquote>

## `sacp-conductor`

<blockquote>

## [1.0.0-alpha.2](https://github.com/symposium-dev/symposium-acp/compare/sacp-conductor-v1.0.0-alpha.1...sacp-conductor-v1.0.0-alpha.2) - 2025-11-08

### Added

- *(sacp)* add convenience methods for common connection patterns

### Other

- fix doctests for API refactoring
- wip wip wip
- wipwipwip
- [**breaking**] remove Unpin bounds and simplify transport API
</blockquote>

## `elizacp`

<blockquote>

## [1.0.0-alpha.2](https://github.com/symposium-dev/symposium-acp/compare/elizacp-v1.0.0-alpha.1...elizacp-v1.0.0-alpha.2) - 2025-11-08

### Other

- Merge pull request #16 from nikomatsakis/main
- wip wip wip
- [**breaking**] remove Unpin bounds and simplify transport API
</blockquote>

## `yopo`

<blockquote>

## [1.0.0-alpha.2](https://github.com/symposium-dev/symposium-acp/compare/yopo-v1.0.0-alpha.1...yopo-v1.0.0-alpha.2) - 2025-11-08

### Other

- Merge pull request #16 from nikomatsakis/main
- wip wip wip
- [**breaking**] remove Unpin bounds and simplify transport API
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).