### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,7 +289,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "elizacp"
-version = "1.0.0-alpha.2"
+version = "1.0.0-alpha.3"
 dependencies = [
  "agent-client-protocol-schema",
  "anyhow",
@@ -850,7 +850,7 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "sacp"
-version = "1.0.0-alpha.2"
+version = "1.0.0-alpha.3"
 dependencies = [
  "agent-client-protocol-schema",
  "anyhow",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "sacp-conductor"
-version = "1.0.0-alpha.2"
+version = "1.0.0-alpha.3"
 dependencies = [
  "agent-client-protocol-schema",
  "anyhow",
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "sacp-proxy"
-version = "1.0.0-alpha.2"
+version = "1.0.0-alpha.3"
 dependencies = [
  "agent-client-protocol-schema",
  "chrono",
@@ -937,7 +937,7 @@ dependencies = [
 
 [[package]]
 name = "sacp-tokio"
-version = "1.0.0-alpha.2"
+version = "1.0.0-alpha.3"
 dependencies = [
  "expect-test",
  "futures",
@@ -1595,7 +1595,7 @@ checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "yopo"
-version = "1.0.0-alpha.2"
+version = "1.0.0-alpha.3"
 dependencies = [
  "sacp",
  "sacp-tokio",

--- a/src/elizacp/CHANGELOG.md
+++ b/src/elizacp/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-alpha.3](https://github.com/symposium-dev/symposium-acp/compare/elizacp-v1.0.0-alpha.2...elizacp-v1.0.0-alpha.3) - 2025-11-09
+
+### Other
+
+- updated the following local packages: sacp
+
 ## [1.0.0-alpha.2](https://github.com/symposium-dev/symposium-acp/compare/elizacp-v1.0.0-alpha.1...elizacp-v1.0.0-alpha.2) - 2025-11-08
 
 ### Other

--- a/src/elizacp/Cargo.toml
+++ b/src/elizacp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elizacp"
-version = "1.0.0-alpha.2"
+version = "1.0.0-alpha.3"
 edition = "2024"
 description = "Classic Eliza chatbot as an ACP agent for testing"
 license = "MIT OR Apache-2.0"
@@ -15,7 +15,7 @@ name = "elizacp"
 path = "src/main.rs"
 
 [dependencies]
-sacp = { version = "1.0.0-alpha.2", path = "../sacp" }
+sacp = { version = "1.0.0-alpha.3", path = "../sacp" }
 agent-client-protocol-schema.workspace = true
 anyhow.workspace = true
 clap.workspace = true

--- a/src/sacp-conductor/CHANGELOG.md
+++ b/src/sacp-conductor/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-alpha.3](https://github.com/symposium-dev/symposium-acp/compare/sacp-conductor-v1.0.0-alpha.2...sacp-conductor-v1.0.0-alpha.3) - 2025-11-09
+
+### Added
+
+- *(sacp-conductor)* implement lazy component initialization
+- *(sacp-conductor)* add ComponentList trait for lazy component instantiation
+
+### Fixed
+
+- *(sacp-conductor)* prevent response messages from overtaking notifications
+
+### Other
+
+- Merge pull request #18 from nikomatsakis/main
+- *(sacp-conductor)* document lazy initialization and ComponentList trait
+- *(sacp-conductor)* use if-let and assert in lazy initialization
+- *(sacp-conductor)* route all message forwarding through central queue
+- *(sacp-conductor)* decouple message handler from component count
+
 ## [1.0.0-alpha.2](https://github.com/symposium-dev/symposium-acp/compare/sacp-conductor-v1.0.0-alpha.1...sacp-conductor-v1.0.0-alpha.2) - 2025-11-08
 
 ### Added

--- a/src/sacp-conductor/Cargo.toml
+++ b/src/sacp-conductor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-conductor"
-version = "1.0.0-alpha.2"
+version = "1.0.0-alpha.3"
 edition = "2024"
 description = "Conductor for orchestrating SACP proxy chains"
 license = "MIT OR Apache-2.0"
@@ -12,9 +12,9 @@ categories = ["development-tools"]
 test-support = []
 
 [dependencies]
-sacp = { version = "1.0.0-alpha.2", path = "../sacp" }
-sacp-proxy = { version = "1.0.0-alpha.2", path = "../sacp-proxy" }
-sacp-tokio = { version = "1.0.0-alpha.2", path = "../sacp-tokio" }
+sacp = { version = "1.0.0-alpha.3", path = "../sacp" }
+sacp-proxy = { version = "1.0.0-alpha.3", path = "../sacp-proxy" }
+sacp-tokio = { version = "1.0.0-alpha.3", path = "../sacp-tokio" }
 agent-client-protocol-schema.workspace = true
 anyhow.workspace = true
 clap.workspace = true

--- a/src/sacp-proxy/CHANGELOG.md
+++ b/src/sacp-proxy/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-alpha.3](https://github.com/symposium-dev/symposium-acp/compare/sacp-proxy-v1.0.0-alpha.2...sacp-proxy-v1.0.0-alpha.3) - 2025-11-09
+
+### Other
+
+- updated the following local packages: sacp
+
 ## [1.0.0-alpha.2](https://github.com/symposium-dev/symposium-acp/compare/sacp-proxy-v1.0.0-alpha.1...sacp-proxy-v1.0.0-alpha.2) - 2025-11-08
 
 ### Other

--- a/src/sacp-proxy/Cargo.toml
+++ b/src/sacp-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-proxy"
-version = "1.0.0-alpha.2"
+version = "1.0.0-alpha.3"
 edition = "2024"
 description = "Framework for building SACP proxy components"
 license = "MIT OR Apache-2.0"
@@ -14,7 +14,7 @@ futures.workspace = true
 fxhash.workspace = true
 jsonrpcmsg.workspace = true
 rmcp.workspace = true
-sacp = { version = "1.0.0-alpha.2", path = "../sacp" }
+sacp = { version = "1.0.0-alpha.3", path = "../sacp" }
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true

--- a/src/sacp-tokio/CHANGELOG.md
+++ b/src/sacp-tokio/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-alpha.3](https://github.com/symposium-dev/symposium-acp/compare/sacp-tokio-v1.0.0-alpha.2...sacp-tokio-v1.0.0-alpha.3) - 2025-11-09
+
+### Other
+
+- updated the following local packages: sacp
+
 ## [1.0.0-alpha.2](https://github.com/symposium-dev/symposium-acp/compare/sacp-tokio-v1.0.0-alpha.1...sacp-tokio-v1.0.0-alpha.2) - 2025-11-08
 
 ### Other

--- a/src/sacp-tokio/Cargo.toml
+++ b/src/sacp-tokio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-tokio"
-version = "1.0.0-alpha.2"
+version = "1.0.0-alpha.3"
 edition = "2024"
 description = "Tokio-based utilities for SACP (Symposium's extensions to ACP)"
 license = "MIT OR Apache-2.0"
@@ -9,7 +9,7 @@ keywords = ["acp", "agent", "protocol", "ai", "tokio"]
 categories = ["development-tools"]
 
 [dependencies]
-sacp = { version = "1.0.0-alpha.2", path = "../sacp" }
+sacp = { version = "1.0.0-alpha.3", path = "../sacp" }
 futures.workspace = true
 jsonrpcmsg.workspace = true
 serde.workspace = true

--- a/src/sacp/CHANGELOG.md
+++ b/src/sacp/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-alpha.3](https://github.com/symposium-dev/symposium-acp/compare/sacp-v1.0.0-alpha.2...sacp-v1.0.0-alpha.3) - 2025-11-09
+
+### Other
+
+- Merge pull request #18 from nikomatsakis/main
+- *(sacp-conductor)* route all message forwarding through central queue
+
 ## [1.0.0-alpha.2](https://github.com/symposium-dev/symposium-acp/compare/sacp-v1.0.0-alpha.1...sacp-v1.0.0-alpha.2) - 2025-11-08
 
 ### Added

--- a/src/sacp/Cargo.toml
+++ b/src/sacp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp"
-version = "1.0.0-alpha.2"
+version = "1.0.0-alpha.3"
 edition = "2024"
 description = "Core protocol types and traits for SACP (Symposium's extensions to ACP)"
 license = "MIT OR Apache-2.0"

--- a/src/yopo/CHANGELOG.md
+++ b/src/yopo/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-alpha.3](https://github.com/symposium-dev/symposium-acp/compare/yopo-v1.0.0-alpha.2...yopo-v1.0.0-alpha.3) - 2025-11-09
+
+### Other
+
+- updated the following local packages: sacp, sacp-tokio
+
 ## [1.0.0-alpha.2](https://github.com/symposium-dev/symposium-acp/compare/yopo-v1.0.0-alpha.1...yopo-v1.0.0-alpha.2) - 2025-11-08
 
 ### Other

--- a/src/yopo/Cargo.toml
+++ b/src/yopo/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "yopo"
-version = "1.0.0-alpha.2"
+version = "1.0.0-alpha.3"
 edition = "2024"
 description = "YOPO (You Only Prompt Once) - A simple ACP client for one-shot prompts"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/symposium-dev/symposium-acp"
 
 [dependencies]
-sacp = { version = "1.0.0-alpha.2", path = "../sacp" }
-sacp-tokio = { version = "1.0.0-alpha.2", path = "../sacp-tokio" }
+sacp = { version = "1.0.0-alpha.3", path = "../sacp" }
+sacp-tokio = { version = "1.0.0-alpha.3", path = "../sacp-tokio" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }


### PR DESCRIPTION



## 🤖 New release

* `sacp`: 1.0.0-alpha.2 -> 1.0.0-alpha.3 (✓ API compatible changes)
* `sacp-test`: 1.0.0-alpha.1
* `sacp-conductor`: 1.0.0-alpha.2 -> 1.0.0-alpha.3 (✓ API compatible changes)
* `sacp-proxy`: 1.0.0-alpha.2 -> 1.0.0-alpha.3
* `sacp-tokio`: 1.0.0-alpha.2 -> 1.0.0-alpha.3
* `elizacp`: 1.0.0-alpha.2 -> 1.0.0-alpha.3
* `yopo`: 1.0.0-alpha.2 -> 1.0.0-alpha.3

<details><summary><i><b>Changelog</b></i></summary><p>

## `sacp`

<blockquote>

## [1.0.0-alpha.3](https://github.com/symposium-dev/symposium-acp/compare/sacp-v1.0.0-alpha.2...sacp-v1.0.0-alpha.3) - 2025-11-09

### Other

- Merge pull request #18 from nikomatsakis/main
- *(sacp-conductor)* route all message forwarding through central queue
</blockquote>

## `sacp-test`

<blockquote>

## [1.0.0-alpha.1](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-test-v1.0.0-alpha.1) - 2025-11-05

### Added

- *(sacp-test)* add arrow proxy for testing

### Other

- update all versions from 1.0.0-alpha to 1.0.0-alpha.1
- release v1.0.0-alpha
- *(conductor)* add integration test with arrow proxy and eliza
- *(conductor)* add integration test with arrow proxy and eliza
- rename sacp-doc-test to sacp-test
</blockquote>

## `sacp-conductor`

<blockquote>

## [1.0.0-alpha.3](https://github.com/symposium-dev/symposium-acp/compare/sacp-conductor-v1.0.0-alpha.2...sacp-conductor-v1.0.0-alpha.3) - 2025-11-09

### Added

- *(sacp-conductor)* implement lazy component initialization
- *(sacp-conductor)* add ComponentList trait for lazy component instantiation

### Fixed

- *(sacp-conductor)* prevent response messages from overtaking notifications

### Other

- Merge pull request #18 from nikomatsakis/main
- *(sacp-conductor)* document lazy initialization and ComponentList trait
- *(sacp-conductor)* use if-let and assert in lazy initialization
- *(sacp-conductor)* route all message forwarding through central queue
- *(sacp-conductor)* decouple message handler from component count
</blockquote>

## `sacp-proxy`

<blockquote>

## [1.0.0-alpha.3](https://github.com/symposium-dev/symposium-acp/compare/sacp-proxy-v1.0.0-alpha.2...sacp-proxy-v1.0.0-alpha.3) - 2025-11-09

### Other

- updated the following local packages: sacp
</blockquote>

## `sacp-tokio`

<blockquote>

## [1.0.0-alpha.3](https://github.com/symposium-dev/symposium-acp/compare/sacp-tokio-v1.0.0-alpha.2...sacp-tokio-v1.0.0-alpha.3) - 2025-11-09

### Other

- updated the following local packages: sacp
</blockquote>

## `elizacp`

<blockquote>

## [1.0.0-alpha.3](https://github.com/symposium-dev/symposium-acp/compare/elizacp-v1.0.0-alpha.2...elizacp-v1.0.0-alpha.3) - 2025-11-09

### Other

- updated the following local packages: sacp
</blockquote>

## `yopo`

<blockquote>

## [1.0.0-alpha.3](https://github.com/symposium-dev/symposium-acp/compare/yopo-v1.0.0-alpha.2...yopo-v1.0.0-alpha.3) - 2025-11-09

### Other

- updated the following local packages: sacp, sacp-tokio
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).