### PR TITLE
chore: release

### DIFF
--- a/src/elizacp/CHANGELOG.md
+++ b/src/elizacp/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-alpha.4](https://github.com/symposium-dev/symposium-acp/compare/elizacp-v1.0.0-alpha.3...elizacp-v1.0.0-alpha.4) - 2025-11-11
+
+### Other
+
+- cleanup and simplify some of the logic to avoid "indirection" through
+
 ## [1.0.0-alpha.3](https://github.com/symposium-dev/symposium-acp/compare/elizacp-v1.0.0-alpha.2...elizacp-v1.0.0-alpha.3) - 2025-11-09
 
 ### Other

--- a/src/elizacp/Cargo.toml
+++ b/src/elizacp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elizacp"
-version = "1.0.0-alpha.3"
+version = "1.0.0-alpha.4"
 edition = "2024"
 description = "Classic Eliza chatbot as an ACP agent for testing"
 license = "MIT OR Apache-2.0"
@@ -15,7 +15,7 @@ name = "elizacp"
 path = "src/main.rs"
 
 [dependencies]
-sacp = { version = "1.0.0-alpha.3", path = "../sacp" }
+sacp = { version = "1.0.0-alpha.4", path = "../sacp" }
 agent-client-protocol-schema.workspace = true
 anyhow.workspace = true
 clap.workspace = true
@@ -29,7 +29,7 @@ tokio-util.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 uuid.workspace = true
-sacp-tokio = { version = "1.0.0-alpha.3", path = "../sacp-tokio" }
+sacp-tokio = { version = "1.0.0-alpha.4", path = "../sacp-tokio" }
 
 [dev-dependencies]
 expect-test.workspace = true

--- a/src/sacp-conductor/CHANGELOG.md
+++ b/src/sacp-conductor/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-alpha.4](https://github.com/symposium-dev/symposium-acp/compare/sacp-conductor-v1.0.0-alpha.3...sacp-conductor-v1.0.0-alpha.4) - 2025-11-11
+
+### Other
+
+- cleanup and simplify some of the logic to avoid "indirection" through
+- remove ComponentProvider trait
+- unify Transport and Component traits with BoxFuture-returning signatures
+- create selective jsonrpcmsg re-export module
+- replace jsonrpcmsg::Message with sacp::JsonRpcMessage throughout codebase
+- move Component trait to sacp-proxy crate
+- *(sacp)* improve IntoJrTransport and Component trait impls
+- *(sacp-conductor)* make Component trait mirror IntoJrTransport interface
+- *(sacp-conductor)* introduce Component trait for better semantics
+
 ## [1.0.0-alpha.3](https://github.com/symposium-dev/symposium-acp/compare/sacp-conductor-v1.0.0-alpha.2...sacp-conductor-v1.0.0-alpha.3) - 2025-11-09
 
 ### Added

--- a/src/sacp-conductor/Cargo.toml
+++ b/src/sacp-conductor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-conductor"
-version = "1.0.0-alpha.3"
+version = "1.0.0-alpha.4"
 edition = "2024"
 description = "Conductor for orchestrating SACP proxy chains"
 license = "MIT OR Apache-2.0"
@@ -12,9 +12,9 @@ categories = ["development-tools"]
 test-support = []
 
 [dependencies]
-sacp = { version = "1.0.0-alpha.3", path = "../sacp" }
-sacp-proxy = { version = "1.0.0-alpha.3", path = "../sacp-proxy" }
-sacp-tokio = { version = "1.0.0-alpha.3", path = "../sacp-tokio" }
+sacp = { version = "1.0.0-alpha.4", path = "../sacp" }
+sacp-proxy = { version = "1.0.0-alpha.4", path = "../sacp-proxy" }
+sacp-tokio = { version = "1.0.0-alpha.4", path = "../sacp-tokio" }
 agent-client-protocol-schema.workspace = true
 anyhow.workspace = true
 clap.workspace = true

--- a/src/sacp-proxy/CHANGELOG.md
+++ b/src/sacp-proxy/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-alpha.4](https://github.com/symposium-dev/symposium-acp/compare/sacp-proxy-v1.0.0-alpha.3...sacp-proxy-v1.0.0-alpha.4) - 2025-11-11
+
+### Other
+
+- unify Transport and Component traits with BoxFuture-returning signatures
+- create selective jsonrpcmsg re-export module
+- replace jsonrpcmsg::Message with sacp::JsonRpcMessage throughout codebase
+- move Component trait to sacp-proxy crate
+
 ## [1.0.0-alpha.3](https://github.com/symposium-dev/symposium-acp/compare/sacp-proxy-v1.0.0-alpha.2...sacp-proxy-v1.0.0-alpha.3) - 2025-11-09
 
 ### Other

--- a/src/sacp-proxy/Cargo.toml
+++ b/src/sacp-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-proxy"
-version = "1.0.0-alpha.3"
+version = "1.0.0-alpha.4"
 edition = "2024"
 description = "Framework for building SACP proxy components"
 license = "MIT OR Apache-2.0"
@@ -14,7 +14,7 @@ futures.workspace = true
 fxhash.workspace = true
 
 rmcp.workspace = true
-sacp = { version = "1.0.0-alpha.3", path = "../sacp" }
+sacp = { version = "1.0.0-alpha.4", path = "../sacp" }
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true

--- a/src/sacp-tokio/CHANGELOG.md
+++ b/src/sacp-tokio/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-alpha.4](https://github.com/symposium-dev/symposium-acp/compare/sacp-tokio-v1.0.0-alpha.3...sacp-tokio-v1.0.0-alpha.4) - 2025-11-11
+
+### Other
+
+- remove ComponentProvider trait
+- unify Transport and Component traits with BoxFuture-returning signatures
+- create selective jsonrpcmsg re-export module
+- replace jsonrpcmsg::Message with sacp::JsonRpcMessage throughout codebase
+
 ## [1.0.0-alpha.3](https://github.com/symposium-dev/symposium-acp/compare/sacp-tokio-v1.0.0-alpha.2...sacp-tokio-v1.0.0-alpha.3) - 2025-11-09
 
 ### Other

--- a/src/sacp-tokio/Cargo.toml
+++ b/src/sacp-tokio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-tokio"
-version = "1.0.0-alpha.3"
+version = "1.0.0-alpha.4"
 edition = "2024"
 description = "Tokio-based utilities for SACP (Symposium's extensions to ACP)"
 license = "MIT OR Apache-2.0"
@@ -9,7 +9,7 @@ keywords = ["acp", "agent", "protocol", "ai", "tokio"]
 categories = ["development-tools"]
 
 [dependencies]
-sacp = { version = "1.0.0-alpha.3", path = "../sacp" }
+sacp = { version = "1.0.0-alpha.4", path = "../sacp" }
 futures.workspace = true
 
 serde.workspace = true

--- a/src/sacp/CHANGELOG.md
+++ b/src/sacp/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-alpha.4](https://github.com/symposium-dev/symposium-acp/compare/sacp-v1.0.0-alpha.3...sacp-v1.0.0-alpha.4) - 2025-11-11
+
+### Other
+
+- unify Transport and Component traits with BoxFuture-returning signatures
+- create selective jsonrpcmsg re-export module
+- move Component trait to sacp-proxy crate
+- *(sacp)* improve IntoJrTransport and Component trait impls
+
 ## [1.0.0-alpha.3](https://github.com/symposium-dev/symposium-acp/compare/sacp-v1.0.0-alpha.2...sacp-v1.0.0-alpha.3) - 2025-11-09
 
 ### Other

--- a/src/sacp/Cargo.toml
+++ b/src/sacp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp"
-version = "1.0.0-alpha.3"
+version = "1.0.0-alpha.4"
 edition = "2024"
 description = "Core protocol types and traits for SACP (Symposium's extensions to ACP)"
 license = "MIT OR Apache-2.0"

--- a/src/yopo/CHANGELOG.md
+++ b/src/yopo/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-alpha.4](https://github.com/symposium-dev/symposium-acp/compare/yopo-v1.0.0-alpha.3...yopo-v1.0.0-alpha.4) - 2025-11-11
+
+### Other
+
+- updated the following local packages: sacp, sacp-tokio
+
 ## [1.0.0-alpha.3](https://github.com/symposium-dev/symposium-acp/compare/yopo-v1.0.0-alpha.2...yopo-v1.0.0-alpha.3) - 2025-11-09
 
 ### Other

--- a/src/yopo/Cargo.toml
+++ b/src/yopo/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "yopo"
-version = "1.0.0-alpha.3"
+version = "1.0.0-alpha.4"
 edition = "2024"
 description = "YOPO (You Only Prompt Once) - A simple ACP client for one-shot prompts"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/symposium-dev/symposium-acp"
 
 [dependencies]
-sacp = { version = "1.0.0-alpha.3", path = "../sacp" }
-sacp-tokio = { version = "1.0.0-alpha.3", path = "../sacp-tokio" }
+sacp = { version = "1.0.0-alpha.4", path = "../sacp" }
+sacp-tokio = { version = "1.0.0-alpha.4", path = "../sacp-tokio" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }


### PR DESCRIPTION



## 🤖 New release

* `sacp`: 1.0.0-alpha.3 -> 1.0.0-alpha.4 (✓ API compatible changes)
* `sacp-proxy`: 1.0.0-alpha.3 -> 1.0.0-alpha.4 (✓ API compatible changes)
* `sacp-test`: 1.0.0-alpha.1
* `sacp-tokio`: 1.0.0-alpha.3 -> 1.0.0-alpha.4 (✓ API compatible changes)
* `sacp-conductor`: 1.0.0-alpha.3 -> 1.0.0-alpha.4 (✓ API compatible changes)
* `elizacp`: 1.0.0-alpha.3 -> 1.0.0-alpha.4 (✓ API compatible changes)
* `yopo`: 1.0.0-alpha.3 -> 1.0.0-alpha.4

<details><summary><i><b>Changelog</b></i></summary><p>

## `sacp`

<blockquote>

## [1.0.0-alpha.4](https://github.com/symposium-dev/symposium-acp/compare/sacp-v1.0.0-alpha.3...sacp-v1.0.0-alpha.4) - 2025-11-11

### Other

- unify Transport and Component traits with BoxFuture-returning signatures
- create selective jsonrpcmsg re-export module
- move Component trait to sacp-proxy crate
- *(sacp)* improve IntoJrTransport and Component trait impls
</blockquote>

## `sacp-proxy`

<blockquote>

## [1.0.0-alpha.4](https://github.com/symposium-dev/symposium-acp/compare/sacp-proxy-v1.0.0-alpha.3...sacp-proxy-v1.0.0-alpha.4) - 2025-11-11

### Other

- unify Transport and Component traits with BoxFuture-returning signatures
- create selective jsonrpcmsg re-export module
- replace jsonrpcmsg::Message with sacp::JsonRpcMessage throughout codebase
- move Component trait to sacp-proxy crate
</blockquote>

## `sacp-test`

<blockquote>

## [1.0.0-alpha.1](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-test-v1.0.0-alpha.1) - 2025-11-05

### Added

- *(sacp-test)* add arrow proxy for testing

### Other

- update all versions from 1.0.0-alpha to 1.0.0-alpha.1
- release v1.0.0-alpha
- *(conductor)* add integration test with arrow proxy and eliza
- *(conductor)* add integration test with arrow proxy and eliza
- rename sacp-doc-test to sacp-test
</blockquote>

## `sacp-tokio`

<blockquote>

## [1.0.0-alpha.4](https://github.com/symposium-dev/symposium-acp/compare/sacp-tokio-v1.0.0-alpha.3...sacp-tokio-v1.0.0-alpha.4) - 2025-11-11

### Other

- remove ComponentProvider trait
- unify Transport and Component traits with BoxFuture-returning signatures
- create selective jsonrpcmsg re-export module
- replace jsonrpcmsg::Message with sacp::JsonRpcMessage throughout codebase
</blockquote>

## `sacp-conductor`

<blockquote>

## [1.0.0-alpha.4](https://github.com/symposium-dev/symposium-acp/compare/sacp-conductor-v1.0.0-alpha.3...sacp-conductor-v1.0.0-alpha.4) - 2025-11-11

### Other

- cleanup and simplify some of the logic to avoid "indirection" through
- remove ComponentProvider trait
- unify Transport and Component traits with BoxFuture-returning signatures
- create selective jsonrpcmsg re-export module
- replace jsonrpcmsg::Message with sacp::JsonRpcMessage throughout codebase
- move Component trait to sacp-proxy crate
- *(sacp)* improve IntoJrTransport and Component trait impls
- *(sacp-conductor)* make Component trait mirror IntoJrTransport interface
- *(sacp-conductor)* introduce Component trait for better semantics
</blockquote>

## `elizacp`

<blockquote>

## [1.0.0-alpha.4](https://github.com/symposium-dev/symposium-acp/compare/elizacp-v1.0.0-alpha.3...elizacp-v1.0.0-alpha.4) - 2025-11-11

### Other

- cleanup and simplify some of the logic to avoid "indirection" through
</blockquote>

## `yopo`

<blockquote>

## [1.0.0-alpha.4](https://github.com/symposium-dev/symposium-acp/compare/yopo-v1.0.0-alpha.3...yopo-v1.0.0-alpha.4) - 2025-11-11

### Other

- updated the following local packages: sacp, sacp-tokio
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).