### PR TITLE
refactor: convert Stdio to unit struct for easier reference

### DIFF
--- a/src/elizacp/src/main.rs
+++ b/src/elizacp/src/main.rs
@@ -70,7 +70,7 @@ async fn main() -> Result<()> {
     tracing::info!("Elizacp starting");
 
     // Run the Eliza agent
-    run_elizacp(sacp_tokio::Stdio::default()).await?;
+    run_elizacp(sacp_tokio::Stdio).await?;
 
     Ok(())
 }

--- a/src/sacp-conductor/src/lib.rs
+++ b/src/sacp-conductor/src/lib.rs
@@ -122,7 +122,7 @@ impl ConductorArgs {
 
                 Conductor::new(name, providers, None)
                     .into_handler_chain()
-                    .connect_to(Stdio::default())?
+                    .connect_to(Stdio)?
                     .serve()
                     .await
             }

--- a/src/sacp-tokio/src/lib.rs
+++ b/src/sacp-tokio/src/lib.rs
@@ -10,10 +10,7 @@ pub use acp_agent::AcpAgent;
 use sacp::{ByteStreams, Transport};
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
-#[derive(Default)]
-pub struct Stdio {
-    _private: (),
-}
+pub struct Stdio;
 
 impl Transport for Stdio {
     fn transport(


### PR DESCRIPTION
- Changed Stdio from struct with private field to unit struct
- Updated usages from Stdio::default() to Stdio
- Simplifies instantiation and makes code more ergonomic