### PR TITLE
chore: release

### DIFF
--- a/src/elizacp/CHANGELOG.md
+++ b/src/elizacp/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-alpha.5](https://github.com/symposium-dev/symposium-acp/compare/elizacp-v1.0.0-alpha.4...elizacp-v1.0.0-alpha.5) - 2025-11-11
+
+### Other
+
+- convert Stdio to unit struct for easier reference
+
 ## [1.0.0-alpha.4](https://github.com/symposium-dev/symposium-acp/compare/elizacp-v1.0.0-alpha.3...elizacp-v1.0.0-alpha.4) - 2025-11-11
 
 ### Other

--- a/src/elizacp/Cargo.toml
+++ b/src/elizacp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elizacp"
-version = "1.0.0-alpha.4"
+version = "1.0.0-alpha.5"
 edition = "2024"
 description = "Classic Eliza chatbot as an ACP agent for testing"
 license = "MIT OR Apache-2.0"
@@ -29,7 +29,7 @@ tokio-util.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 uuid.workspace = true
-sacp-tokio = { version = "1.0.0-alpha.4", path = "../sacp-tokio" }
+sacp-tokio = { version = "1.0.0-alpha.5", path = "../sacp-tokio" }
 
 [dev-dependencies]
 expect-test.workspace = true

--- a/src/sacp-conductor/CHANGELOG.md
+++ b/src/sacp-conductor/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-alpha.5](https://github.com/symposium-dev/symposium-acp/compare/sacp-conductor-v1.0.0-alpha.4...sacp-conductor-v1.0.0-alpha.5) - 2025-11-11
+
+### Other
+
+- convert Stdio to unit struct for easier reference
+
 ## [1.0.0-alpha.4](https://github.com/symposium-dev/symposium-acp/compare/sacp-conductor-v1.0.0-alpha.3...sacp-conductor-v1.0.0-alpha.4) - 2025-11-11
 
 ### Other

--- a/src/sacp-conductor/Cargo.toml
+++ b/src/sacp-conductor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-conductor"
-version = "1.0.0-alpha.4"
+version = "1.0.0-alpha.5"
 edition = "2024"
 description = "Conductor for orchestrating SACP proxy chains"
 license = "MIT OR Apache-2.0"
@@ -14,7 +14,7 @@ test-support = []
 [dependencies]
 sacp = { version = "1.0.0-alpha.4", path = "../sacp" }
 sacp-proxy = { version = "1.0.0-alpha.4", path = "../sacp-proxy" }
-sacp-tokio = { version = "1.0.0-alpha.4", path = "../sacp-tokio" }
+sacp-tokio = { version = "1.0.0-alpha.5", path = "../sacp-tokio" }
 agent-client-protocol-schema.workspace = true
 anyhow.workspace = true
 clap.workspace = true

--- a/src/sacp-tokio/CHANGELOG.md
+++ b/src/sacp-tokio/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-alpha.5](https://github.com/symposium-dev/symposium-acp/compare/sacp-tokio-v1.0.0-alpha.4...sacp-tokio-v1.0.0-alpha.5) - 2025-11-11
+
+### Other
+
+- convert Stdio to unit struct for easier reference
+
 ## [1.0.0-alpha.4](https://github.com/symposium-dev/symposium-acp/compare/sacp-tokio-v1.0.0-alpha.3...sacp-tokio-v1.0.0-alpha.4) - 2025-11-11
 
 ### Other

--- a/src/sacp-tokio/Cargo.toml
+++ b/src/sacp-tokio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-tokio"
-version = "1.0.0-alpha.4"
+version = "1.0.0-alpha.5"
 edition = "2024"
 description = "Tokio-based utilities for SACP (Symposium's extensions to ACP)"
 license = "MIT OR Apache-2.0"

--- a/src/yopo/CHANGELOG.md
+++ b/src/yopo/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-alpha.5](https://github.com/symposium-dev/symposium-acp/compare/yopo-v1.0.0-alpha.4...yopo-v1.0.0-alpha.5) - 2025-11-11
+
+### Other
+
+- updated the following local packages: sacp-tokio
+
 ## [1.0.0-alpha.4](https://github.com/symposium-dev/symposium-acp/compare/yopo-v1.0.0-alpha.3...yopo-v1.0.0-alpha.4) - 2025-11-11
 
 ### Other

--- a/src/yopo/Cargo.toml
+++ b/src/yopo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yopo"
-version = "1.0.0-alpha.4"
+version = "1.0.0-alpha.5"
 edition = "2024"
 description = "YOPO (You Only Prompt Once) - A simple ACP client for one-shot prompts"
 license = "MIT OR Apache-2.0"
@@ -8,5 +8,5 @@ repository = "https://github.com/symposium-dev/symposium-acp"
 
 [dependencies]
 sacp = { version = "1.0.0-alpha.4", path = "../sacp" }
-sacp-tokio = { version = "1.0.0-alpha.4", path = "../sacp-tokio" }
+sacp-tokio = { version = "1.0.0-alpha.5", path = "../sacp-tokio" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }


### PR DESCRIPTION



## 🤖 New release

* `sacp-test`: 1.0.0-alpha.1
* `sacp-tokio`: 1.0.0-alpha.4 -> 1.0.0-alpha.5 (✓ API compatible changes)
* `sacp-conductor`: 1.0.0-alpha.4 -> 1.0.0-alpha.5 (✓ API compatible changes)
* `elizacp`: 1.0.0-alpha.4 -> 1.0.0-alpha.5 (✓ API compatible changes)
* `yopo`: 1.0.0-alpha.4 -> 1.0.0-alpha.5

<details><summary><i><b>Changelog</b></i></summary><p>

## `sacp-test`

<blockquote>

## [1.0.0-alpha.1](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-test-v1.0.0-alpha.1) - 2025-11-05

### Added

- *(sacp-test)* add arrow proxy for testing

### Other

- update all versions from 1.0.0-alpha to 1.0.0-alpha.1
- release v1.0.0-alpha
- *(conductor)* add integration test with arrow proxy and eliza
- *(conductor)* add integration test with arrow proxy and eliza
- rename sacp-doc-test to sacp-test
</blockquote>

## `sacp-tokio`

<blockquote>

## [1.0.0-alpha.5](https://github.com/symposium-dev/symposium-acp/compare/sacp-tokio-v1.0.0-alpha.4...sacp-tokio-v1.0.0-alpha.5) - 2025-11-11

### Other

- convert Stdio to unit struct for easier reference
</blockquote>

## `sacp-conductor`

<blockquote>

## [1.0.0-alpha.5](https://github.com/symposium-dev/symposium-acp/compare/sacp-conductor-v1.0.0-alpha.4...sacp-conductor-v1.0.0-alpha.5) - 2025-11-11

### Other

- convert Stdio to unit struct for easier reference
</blockquote>

## `elizacp`

<blockquote>

## [1.0.0-alpha.5](https://github.com/symposium-dev/symposium-acp/compare/elizacp-v1.0.0-alpha.4...elizacp-v1.0.0-alpha.5) - 2025-11-11

### Other

- convert Stdio to unit struct for easier reference
</blockquote>

## `yopo`

<blockquote>

## [1.0.0-alpha.5](https://github.com/symposium-dev/symposium-acp/compare/yopo-v1.0.0-alpha.4...yopo-v1.0.0-alpha.5) - 2025-11-11

### Other

- updated the following local packages: sacp-tokio
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).