### PR TITLE
chore: release

### DIFF
--- a/src/sacp-conductor/CHANGELOG.md
+++ b/src/sacp-conductor/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-alpha.6](https://github.com/symposium-dev/symposium-acp/compare/sacp-conductor-v1.0.0-alpha.5...sacp-conductor-v1.0.0-alpha.6) - 2025-11-11
+
+### Added
+
+- *(sacp-conductor)* implement Component trait for Conductor
+- *(sacp-conductor)* add SYMPOSIUM_LOG environment variable for file logging
+
+### Other
+
+- Merge pull request #24 from nikomatsakis/main
+
 ## [1.0.0-alpha.5](https://github.com/symposium-dev/symposium-acp/compare/sacp-conductor-v1.0.0-alpha.4...sacp-conductor-v1.0.0-alpha.5) - 2025-11-11
 
 ### Other

--- a/src/sacp-conductor/Cargo.toml
+++ b/src/sacp-conductor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-conductor"
-version = "1.0.0-alpha.5"
+version = "1.0.0-alpha.6"
 edition = "2024"
 description = "Conductor for orchestrating SACP proxy chains"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `sacp-test`: 1.0.0-alpha.1
* `sacp-conductor`: 1.0.0-alpha.5 -> 1.0.0-alpha.6 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `sacp-test`

<blockquote>

## [1.0.0-alpha.1](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-test-v1.0.0-alpha.1) - 2025-11-05

### Added

- *(sacp-test)* add arrow proxy for testing

### Other

- update all versions from 1.0.0-alpha to 1.0.0-alpha.1
- release v1.0.0-alpha
- *(conductor)* add integration test with arrow proxy and eliza
- *(conductor)* add integration test with arrow proxy and eliza
- rename sacp-doc-test to sacp-test
</blockquote>

## `sacp-conductor`

<blockquote>

## [1.0.0-alpha.6](https://github.com/symposium-dev/symposium-acp/compare/sacp-conductor-v1.0.0-alpha.5...sacp-conductor-v1.0.0-alpha.6) - 2025-11-11

### Added

- *(sacp-conductor)* implement Component trait for Conductor
- *(sacp-conductor)* add SYMPOSIUM_LOG environment variable for file logging

### Other

- Merge pull request #24 from nikomatsakis/main
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).