### PR TITLE
chore: release

### DIFF
--- a/src/elizacp/CHANGELOG.md
+++ b/src/elizacp/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-alpha.8](https://github.com/symposium-dev/symposium-acp/compare/elizacp-v1.0.0-alpha.7...elizacp-v1.0.0-alpha.8) - 2025-11-12
+
+### Other
+
+- Merge pull request #30 from nikomatsakis/main
+- *(sacp)* remove Deref impl from JrRequestCx
+
 ## [1.0.0-alpha.7](https://github.com/symposium-dev/symposium-acp/compare/elizacp-v1.0.0-alpha.6...elizacp-v1.0.0-alpha.7) - 2025-11-12
 
 ### Other

--- a/src/elizacp/Cargo.toml
+++ b/src/elizacp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elizacp"
-version = "1.0.0-alpha.7"
+version = "1.0.0-alpha.8"
 edition = "2024"
 description = "Classic Eliza chatbot as an ACP agent for testing"
 license = "MIT OR Apache-2.0"
@@ -15,7 +15,7 @@ name = "elizacp"
 path = "src/main.rs"
 
 [dependencies]
-sacp = { version = "1.0.0-alpha.6", path = "../sacp" }
+sacp = { version = "1.0.0-alpha.7", path = "../sacp" }
 agent-client-protocol-schema.workspace = true
 anyhow.workspace = true
 clap.workspace = true
@@ -29,7 +29,7 @@ tokio-util.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 uuid.workspace = true
-sacp-tokio = { version = "1.0.0-alpha.7", path = "../sacp-tokio" }
+sacp-tokio = { version = "1.0.0-alpha.8", path = "../sacp-tokio" }
 
 [dev-dependencies]
 expect-test.workspace = true

--- a/src/sacp-conductor/CHANGELOG.md
+++ b/src/sacp-conductor/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-alpha.9](https://github.com/symposium-dev/symposium-acp/compare/sacp-conductor-v1.0.0-alpha.8...sacp-conductor-v1.0.0-alpha.9) - 2025-11-12
+
+### Other
+
+- Merge pull request #30 from nikomatsakis/main
+- *(sacp)* remove Deref impl from JrRequestCx
+- *(sacp)* add Component::serve() and simplify channel API
+
 ## [1.0.0-alpha.8](https://github.com/symposium-dev/symposium-acp/compare/sacp-conductor-v1.0.0-alpha.7...sacp-conductor-v1.0.0-alpha.8) - 2025-11-12
 
 ### Other

--- a/src/sacp-conductor/Cargo.toml
+++ b/src/sacp-conductor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-conductor"
-version = "1.0.0-alpha.8"
+version = "1.0.0-alpha.9"
 edition = "2024"
 description = "Conductor for orchestrating SACP proxy chains"
 license = "MIT OR Apache-2.0"
@@ -12,9 +12,9 @@ categories = ["development-tools"]
 test-support = []
 
 [dependencies]
-sacp = { version = "1.0.0-alpha.6", path = "../sacp" }
-sacp-proxy = { version = "1.0.0-alpha.6", path = "../sacp-proxy" }
-sacp-tokio = { version = "1.0.0-alpha.7", path = "../sacp-tokio" }
+sacp = { version = "1.0.0-alpha.7", path = "../sacp" }
+sacp-proxy = { version = "1.0.0-alpha.7", path = "../sacp-proxy" }
+sacp-tokio = { version = "1.0.0-alpha.8", path = "../sacp-tokio" }
 agent-client-protocol-schema.workspace = true
 anyhow.workspace = true
 chrono.workspace = true

--- a/src/sacp-proxy/CHANGELOG.md
+++ b/src/sacp-proxy/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-alpha.7](https://github.com/symposium-dev/symposium-acp/compare/sacp-proxy-v1.0.0-alpha.6...sacp-proxy-v1.0.0-alpha.7) - 2025-11-12
+
+### Other
+
+- Merge pull request #30 from nikomatsakis/main
+- *(sacp)* remove Deref impl from JrRequestCx
+
 ## [1.0.0-alpha.6](https://github.com/symposium-dev/symposium-acp/compare/sacp-proxy-v1.0.0-alpha.5...sacp-proxy-v1.0.0-alpha.6) - 2025-11-12
 
 ### Other

--- a/src/sacp-proxy/Cargo.toml
+++ b/src/sacp-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-proxy"
-version = "1.0.0-alpha.6"
+version = "1.0.0-alpha.7"
 edition = "2024"
 description = "Framework for building SACP proxy components"
 license = "MIT OR Apache-2.0"
@@ -14,7 +14,7 @@ futures.workspace = true
 fxhash.workspace = true
 
 rmcp.workspace = true
-sacp = { version = "1.0.0-alpha.6", path = "../sacp" }
+sacp = { version = "1.0.0-alpha.7", path = "../sacp" }
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true

--- a/src/sacp-tokio/CHANGELOG.md
+++ b/src/sacp-tokio/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-alpha.8](https://github.com/symposium-dev/symposium-acp/compare/sacp-tokio-v1.0.0-alpha.7...sacp-tokio-v1.0.0-alpha.8) - 2025-11-12
+
+### Other
+
+- Merge pull request #30 from nikomatsakis/main
+- *(sacp)* add Component::serve() and simplify channel API
+
 ## [1.0.0-alpha.7](https://github.com/symposium-dev/symposium-acp/compare/sacp-tokio-v1.0.0-alpha.6...sacp-tokio-v1.0.0-alpha.7) - 2025-11-12
 
 ### Other

--- a/src/sacp-tokio/Cargo.toml
+++ b/src/sacp-tokio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-tokio"
-version = "1.0.0-alpha.7"
+version = "1.0.0-alpha.8"
 edition = "2024"
 description = "Tokio-based utilities for SACP (Symposium's extensions to ACP)"
 license = "MIT OR Apache-2.0"
@@ -9,7 +9,7 @@ keywords = ["acp", "agent", "protocol", "ai", "tokio"]
 categories = ["development-tools"]
 
 [dependencies]
-sacp = { version = "1.0.0-alpha.6", path = "../sacp" }
+sacp = { version = "1.0.0-alpha.7", path = "../sacp" }
 futures.workspace = true
 
 serde.workspace = true

--- a/src/sacp/CHANGELOG.md
+++ b/src/sacp/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-alpha.7](https://github.com/symposium-dev/symposium-acp/compare/sacp-v1.0.0-alpha.6...sacp-v1.0.0-alpha.7) - 2025-11-12
+
+### Other
+
+- Merge pull request #30 from nikomatsakis/main
+- *(sacp)* remove Deref impl from JrRequestCx
+- *(sacp)* add common patterns section to crate-level documentation
+- *(sacp)* add Component::serve() and simplify channel API
+
 ## [1.0.0-alpha.6](https://github.com/symposium-dev/symposium-acp/compare/sacp-v1.0.0-alpha.5...sacp-v1.0.0-alpha.6) - 2025-11-12
 
 ### Added

--- a/src/sacp/Cargo.toml
+++ b/src/sacp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp"
-version = "1.0.0-alpha.6"
+version = "1.0.0-alpha.7"
 edition = "2024"
 description = "Core protocol types and traits for SACP (Symposium's extensions to ACP)"
 license = "MIT OR Apache-2.0"

--- a/src/yopo/CHANGELOG.md
+++ b/src/yopo/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-alpha.8](https://github.com/symposium-dev/symposium-acp/compare/yopo-v1.0.0-alpha.7...yopo-v1.0.0-alpha.8) - 2025-11-12
+
+### Other
+
+- updated the following local packages: sacp, sacp-tokio
+
 ## [1.0.0-alpha.7](https://github.com/symposium-dev/symposium-acp/compare/yopo-v1.0.0-alpha.6...yopo-v1.0.0-alpha.7) - 2025-11-12
 
 ### Other

--- a/src/yopo/Cargo.toml
+++ b/src/yopo/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "yopo"
-version = "1.0.0-alpha.7"
+version = "1.0.0-alpha.8"
 edition = "2024"
 description = "YOPO (You Only Prompt Once) - A simple ACP client for one-shot prompts"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/symposium-dev/symposium-acp"
 
 [dependencies]
-sacp = { version = "1.0.0-alpha.6", path = "../sacp" }
-sacp-tokio = { version = "1.0.0-alpha.7", path = "../sacp-tokio" }
+sacp = { version = "1.0.0-alpha.7", path = "../sacp" }
+sacp-tokio = { version = "1.0.0-alpha.8", path = "../sacp-tokio" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }


### PR DESCRIPTION



## 🤖 New release

* `sacp`: 1.0.0-alpha.6 -> 1.0.0-alpha.7 (✓ API compatible changes)
* `sacp-proxy`: 1.0.0-alpha.6 -> 1.0.0-alpha.7 (✓ API compatible changes)
* `sacp-test`: 1.0.0-alpha.1
* `sacp-tokio`: 1.0.0-alpha.7 -> 1.0.0-alpha.8 (✓ API compatible changes)
* `sacp-conductor`: 1.0.0-alpha.8 -> 1.0.0-alpha.9 (✓ API compatible changes)
* `elizacp`: 1.0.0-alpha.7 -> 1.0.0-alpha.8 (✓ API compatible changes)
* `yopo`: 1.0.0-alpha.7 -> 1.0.0-alpha.8

<details><summary><i><b>Changelog</b></i></summary><p>

## `sacp`

<blockquote>

## [1.0.0-alpha.7](https://github.com/symposium-dev/symposium-acp/compare/sacp-v1.0.0-alpha.6...sacp-v1.0.0-alpha.7) - 2025-11-12

### Other

- Merge pull request #30 from nikomatsakis/main
- *(sacp)* remove Deref impl from JrRequestCx
- *(sacp)* add common patterns section to crate-level documentation
- *(sacp)* add Component::serve() and simplify channel API
</blockquote>

## `sacp-proxy`

<blockquote>

## [1.0.0-alpha.7](https://github.com/symposium-dev/symposium-acp/compare/sacp-proxy-v1.0.0-alpha.6...sacp-proxy-v1.0.0-alpha.7) - 2025-11-12

### Other

- Merge pull request #30 from nikomatsakis/main
- *(sacp)* remove Deref impl from JrRequestCx
</blockquote>

## `sacp-test`

<blockquote>

## [1.0.0-alpha.1](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-test-v1.0.0-alpha.1) - 2025-11-05

### Added

- *(sacp-test)* add arrow proxy for testing

### Other

- update all versions from 1.0.0-alpha to 1.0.0-alpha.1
- release v1.0.0-alpha
- *(conductor)* add integration test with arrow proxy and eliza
- *(conductor)* add integration test with arrow proxy and eliza
- rename sacp-doc-test to sacp-test
</blockquote>

## `sacp-tokio`

<blockquote>

## [1.0.0-alpha.8](https://github.com/symposium-dev/symposium-acp/compare/sacp-tokio-v1.0.0-alpha.7...sacp-tokio-v1.0.0-alpha.8) - 2025-11-12

### Other

- Merge pull request #30 from nikomatsakis/main
- *(sacp)* add Component::serve() and simplify channel API
</blockquote>

## `sacp-conductor`

<blockquote>

## [1.0.0-alpha.9](https://github.com/symposium-dev/symposium-acp/compare/sacp-conductor-v1.0.0-alpha.8...sacp-conductor-v1.0.0-alpha.9) - 2025-11-12

### Other

- Merge pull request #30 from nikomatsakis/main
- *(sacp)* remove Deref impl from JrRequestCx
- *(sacp)* add Component::serve() and simplify channel API
</blockquote>

## `elizacp`

<blockquote>

## [1.0.0-alpha.8](https://github.com/symposium-dev/symposium-acp/compare/elizacp-v1.0.0-alpha.7...elizacp-v1.0.0-alpha.8) - 2025-11-12

### Other

- Merge pull request #30 from nikomatsakis/main
- *(sacp)* remove Deref impl from JrRequestCx
</blockquote>

## `yopo`

<blockquote>

## [1.0.0-alpha.8](https://github.com/symposium-dev/symposium-acp/compare/yopo-v1.0.0-alpha.7...yopo-v1.0.0-alpha.8) - 2025-11-12

### Other

- updated the following local packages: sacp, sacp-tokio
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).