### PR TITLE
docs: update building-proxy guide to reflect 1.0 Component API

### DIFF
--- a/md/building-proxy.md
+++ b/md/building-proxy.md
@@ -1,122 +1,151 @@
 # Building a Proxy
 
-This chapter explains how to build a proxy component using the `sacp-proxy` crate.
+This chapter explains how to build a proxy component using the `sacp` and `sacp-proxy` crates.
 
 ## Overview
 
-A proxy component intercepts messages between editors and agents, transforming them or adding side effects. Proxies are built using the `sacp-proxy` framework.
+A proxy component intercepts messages between editors and agents, transforming them or adding side effects. Proxies are built using the `Component` trait from `sacp` and helper extensions from `sacp-proxy`.
 
 ## Basic Structure
 
 ```rust
-use sacp_proxy::{AcpProxyExt, JsonRpcCxExt, ProxyHandler};
-use sacp::{JsonRpcConnection, JsonRpcHandler};
+use sacp::{Component, JrHandlerChain, MessageAndCx};
+use sacp::schema::{PromptRequest, InitializeRequest};
 
-// Your proxy's main handler
 struct MyProxy {
     // State fields
 }
 
-impl JsonRpcHandler for MyProxy {
-    async fn handle_message(&mut self, message: MessageAndCx) -> Result<Handled> {
-        match message {
-            // Handle messages from upstream (editor direction)
-            MessageAndCx::Request(req, cx) => {
-                match req {
-                    // Transform and forward
-                    AcpRequest::Prompt(mut prompt) => {
-                        // Modify the prompt
-                        prompt.messages.insert(0, my_context);
-                        
-                        // Forward to successor
-                        cx.send_request_to_successor(prompt)
-                          .await_when_result_received(|result| {
-                              cx.respond_with_result(result)
-                          })
-                    }
-                    // Other message types...
-                }
-            }
-            MessageAndCx::Notification(notif, cx) => {
-                // Handle notifications
-            }
-        }
+impl Component for MyProxy {
+    async fn serve(self, client: impl Component) -> Result<(), sacp::Error> {
+        JrHandlerChain::new()
+            .name("my-proxy")
+            .on_receive_request(async move |req: PromptRequest, cx| {
+                // Transform the prompt
+                let mut modified = req;
+                modified.messages.insert(0, my_context_message());
+                
+                // Forward to successor and relay response back
+                cx.send_request(modified)
+                    .await_when_result_received(async move |result| {
+                        cx.respond_with_result(result)
+                    })
+            })
+            .serve(client)
+            .await
     }
 }
 ```
 
-## Key Traits
+## Key Concepts
 
-### `AcpProxyExt`
+### Component Composition
 
-Provides methods for handling messages from the successor:
-
-```rust
-use sacp_proxy::AcpProxyExt;
-
-connection
-    .on_receive_request_from_successor(|req, cx| async move {
-        // Handle request from downstream component
-    })
-    .on_receive_notification_from_successor(|notif, cx| async move {
-        // Handle notification from downstream
-    })
-    .proxy() // Enable automatic proxy capability handshake
-```
-
-### `JsonRpcCxExt`
-
-Provides methods for sending to successor:
+The `Component` trait enables composition through the `serve()` method. Each component receives the next component in the chain as the `client` parameter:
 
 ```rust
-use sacp_proxy::JsonRpcCxExt;
-
-// Send request and handle response
-cx.send_request_to_successor(request)
-  .await_when_result_received(|result| {
-      cx.respond_with_result(result)
-  })
-
-// Send notification (fire and forget)
-cx.send_notification_to_successor(notification)
+impl Component for MyProxy {
+    async fn serve(self, client: impl Component) -> Result<(), sacp::Error> {
+        // Set up handlers that forward to `client`
+        JrHandlerChain::new()
+            .on_receive_request(async move |req, cx| {
+                // Process and forward to client
+            })
+            .serve(client)
+            .await
+    }
+}
 ```
 
-## Proxy Patterns
+### Non-Blocking Message Handlers
+
+**Important:** Message handlers run on the event loop. Blocking in a handler will prevent the connection from processing new messages.
+
+Use `await_when_*` methods to avoid blocking:
+
+```rust
+.on_receive_request(async move |req: PromptRequest, cx| {
+    // This sends the request without blocking
+    cx.send_request(req)
+        .await_when_result_received(async move |result| {
+            // This runs after the response is received
+            cx.respond_with_result(result)
+        })
+})
+```
+
+Or use `cx.spawn()` for background work:
+
+```rust
+.on_receive_request(async move |req: PromptRequest, cx| {
+    let connection_cx = cx.connection_cx();
+    cx.spawn(async move {
+        // Expensive work here won't block the message loop
+        let result = expensive_computation(req).await;
+        connection_cx.send_notification(ComputationComplete { result });
+    });
+    cx.respond(AckResponse {})
+})
+```
+
+## Common Proxy Patterns
 
 ### Pass-through Proxy
 
 The simplest proxy forwards everything unchanged:
 
 ```rust
-impl JsonRpcHandler for PassThrough {
-    async fn handle_message(&mut self, message: MessageAndCx) -> Result<Handled> {
-        match message {
-            MessageAndCx::Request(req, cx) => {
-                cx.send_request_to_successor(req)
-                  .await_when_result_received(|r| cx.respond_with_result(r))
-            }
-            MessageAndCx::Notification(notif, cx) => {
-                cx.send_notification_to_successor(notif)
-            }
-        }
+impl Component for PassThrough {
+    async fn serve(self, client: impl Component) -> Result<(), sacp::Error> {
+        // Just serve the client directly - no interception needed
+        client.serve(sacp::ByteStreams::stdio()).await
     }
 }
 ```
 
-### Initialization Injection
-
-Inject context or configuration during initialization:
+For selective forwarding with some message handling:
 
 ```rust
-MessageAndCx::Request(AcpRequest::Initialize(mut init), cx) => {
-    // Add your capabilities
-    init.capabilities.my_feature = true;
-    
-    cx.send_request_to_successor(init)
-      .await_when_result_received(|result| {
-          cx.respond_with_result(result)
-      })
+impl Component for SelectiveProxy {
+    async fn serve(self, client: impl Component) -> Result<(), sacp::Error> {
+        JrHandlerChain::new()
+            .name("selective-proxy")
+            .on_receive_request(async move |req: PromptRequest, cx| {
+                // Handle prompts specially
+                let modified = transform_prompt(req);
+                cx.send_request(modified)
+                    .await_when_result_received(async move |result| {
+                        cx.respond_with_result(result)
+                    })
+            })
+            // All other messages forward through automatically
+            .serve(client)
+            .await
+    }
 }
+```
+
+### Initialization Enhancement
+
+Intercept initialization to inject capabilities or configuration:
+
+```rust
+.on_receive_request(async move |req: InitializeRequest, cx| {
+    // Forward to successor to get their capabilities
+    cx.send_request(req)
+        .await_when_result_received(async move |mut result| {
+            match &mut result {
+                Ok(init_response) => {
+                    // Add our capabilities
+                    init_response.agent_capabilities.my_feature = true;
+                }
+                Err(_) => {
+                    // Pass errors through unchanged
+                }
+            }
+            cx.respond_with_result(result)
+        })
+})
 ```
 
 ### Prompt Transformation
@@ -124,41 +153,167 @@ MessageAndCx::Request(AcpRequest::Initialize(mut init), cx) => {
 Modify prompts before they reach the agent:
 
 ```rust
-MessageAndCx::Request(AcpRequest::Prompt(mut prompt), cx) => {
+.on_receive_request(async move |req: PromptRequest, cx| {
+    let mut modified = req;
+    
     // Prepend system context
     let context_message = Message {
         role: Role::User,
-        content: vec![Content::Text { text: context }],
+        content: Content::text("Additional context here"),
     };
-    prompt.messages.insert(0, context_message);
+    modified.messages.insert(0, context_message);
     
-    cx.send_request_to_successor(prompt)
-      .await_when_result_received(|result| {
-          cx.respond_with_result(result)
-      })
-}
+    cx.send_request(modified)
+        .await_when_result_received(async move |result| {
+            cx.respond_with_result(result)
+        })
+})
+```
+
+### Response Transformation
+
+Transform responses before they return to the editor:
+
+```rust
+.on_receive_request(async move |req: PromptRequest, cx| {
+    cx.send_request(req)
+        .await_when_result_received(async move |result| {
+            let transformed = match result {
+                Ok(mut response) => {
+                    // Modify the response
+                    response.content = post_process(response.content);
+                    Ok(response)
+                }
+                Err(e) => Err(e),
+            };
+            cx.respond_with_result(transformed)
+        })
+})
 ```
 
 ### MCP Server Provider
 
-Provide MCP servers to the agent:
+Provide MCP servers to downstream components using the `sacp-proxy` crate:
 
 ```rust
-use sacp_proxy::AcpProxyExt;
+use sacp_proxy::ProxyExt;
 
-connection
-    .provide_mcp(my_mcp_server_uuid, my_mcp_handler)
-    .proxy()
+impl Component for McpProvider {
+    async fn serve(self, client: impl Component) -> Result<(), sacp::Error> {
+        JrHandlerChain::new()
+            .name("mcp-provider")
+            .provide_mcp(self.server_id, self.mcp_handler)
+            .serve(client)
+            .await
+    }
+}
 ```
 
 See the Protocol Reference for details on the MCP-over-ACP protocol.
 
+### Stateful Proxy with Custom Handler
+
+For more complex state management, implement `JrMessageHandler`:
+
+```rust
+use sacp::{JrMessageHandler, Handled};
+use sacp::util::MatchMessage;
+use std::sync::{Arc, Mutex};
+
+struct StatefulProxy {
+    state: Arc<Mutex<ProxyState>>,
+}
+
+impl JrMessageHandler for StatefulProxy {
+    async fn handle_message(&mut self, message: MessageAndCx)
+        -> Result<Handled<MessageAndCx>, sacp::Error>
+    {
+        MatchMessage::new(message)
+            .if_request(async |req: PromptRequest, cx| {
+                let mut state = self.state.lock().unwrap();
+                state.request_count += 1;
+                
+                // Transform based on state
+                let modified = state.transform_request(req);
+                
+                cx.send_request(modified)
+                    .await_when_result_received(async move |result| {
+                        cx.respond_with_result(result)
+                    })
+            })
+            .await
+            .done()
+    }
+
+    fn describe_chain(&self) -> impl std::fmt::Debug {
+        "StatefulProxy"
+    }
+}
+```
+
+## Request Context Capabilities
+
+The [`JrRequestCx`] provided to handlers offers several capabilities:
+
+- **Respond to the request:** `cx.respond(response)` or `cx.respond_with_result(result)`
+- **Send requests downstream:** `cx.send_request(request)` 
+- **Send notifications:** `cx.send_notification(notification)`
+- **Spawn background tasks:** `cx.spawn(future)`
+- **Get connection context:** `cx.connection_cx()` for contexts not tied to a specific request
+
 ## Complete Example
 
-For a complete example of a production proxy, see the [sparkle-acp-proxy](https://github.com/nikomatsakis/sparkle-acp-proxy) implementation.
+Here's a complete proxy that logs all prompts and adds timing information:
+
+```rust
+use sacp::{Component, JrHandlerChain};
+use sacp::schema::{PromptRequest, PromptResponse};
+use std::time::Instant;
+
+struct LoggingProxy;
+
+impl Component for LoggingProxy {
+    async fn serve(self, client: impl Component) -> Result<(), sacp::Error> {
+        JrHandlerChain::new()
+            .name("logging-proxy")
+            .on_receive_request(async move |req: PromptRequest, cx| {
+                let start = Instant::now();
+                tracing::info!(
+                    "Prompt received with {} messages",
+                    req.messages.len()
+                );
+                
+                cx.send_request(req)
+                    .await_when_result_received(async move |result| {
+                        let elapsed = start.elapsed();
+                        tracing::info!("Response received in {:?}", elapsed);
+                        cx.respond_with_result(result)
+                    })
+            })
+            .serve(client)
+            .await
+    }
+}
+```
+
+## Testing Your Proxy
+
+Use `sacp-test` helpers for testing components:
+
+```rust
+#[tokio::test]
+async fn test_my_proxy() {
+    let proxy = MyProxy::new();
+    let mock_agent = MockAgent::new();
+    
+    // Test the proxy
+    proxy.serve(mock_agent).await.unwrap();
+}
+```
 
 ## Next Steps
 
 - See [Protocol Reference](./protocol.md) for message format details
-- Read the `sacp-proxy` crate documentation for API details
-- Study the sparkle-acp-proxy implementation for patterns
+- Read the `sacp` crate documentation for complete API details
+- Study the [sparkle-acp-proxy](https://github.com/nikomatsakis/sparkle-acp-proxy) for a production example
+- Check [Component Architecture](./pacp-components.md) for proxy chain design patterns


### PR DESCRIPTION
Replace outdated JsonRpcHandler examples with current Component trait patterns. Update all code examples to use JrHandlerChain and the simplified API from the 1.0 release. Add sections on non-blocking handlers and common proxy patterns that align with the crate-level documentation.