### PR TITLE
refactor(sacp-proxy)!: move rmcp integration to separate sacp-rmcp crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,10 @@ members = [
     "src/sacp-conductor",
     "src/sacp",
     "src/sacp-tokio",
+    "src/sacp-rmcp",
     "src/elizacp",
-    "src/sacp-test", "src/yopo",
+    "src/sacp-test",
+    "src/yopo",
 ]
 resolver = "2"
 

--- a/src/sacp-conductor/Cargo.toml
+++ b/src/sacp-conductor/Cargo.toml
@@ -39,3 +39,4 @@ rmcp = { workspace = true, features = ["client", "server", "transport-io", "tran
 schemars.workspace = true
 sacp-test = { path = "../sacp-test" }
 sacp-tokio = { path = "../sacp-tokio" }
+sacp-rmcp = { path = "../sacp-rmcp" }

--- a/src/sacp-conductor/tests/mcp_integration/proxy.rs
+++ b/src/sacp-conductor/tests/mcp_integration/proxy.rs
@@ -2,6 +2,7 @@
 
 use sacp::{Component, JrHandlerChain};
 use sacp_proxy::{AcpProxyExt, McpServiceRegistry};
+use sacp_rmcp::McpServiceRegistryRmcpExt;
 
 use crate::mcp_integration::mcp_server::TestMcpServer;
 

--- a/src/sacp-proxy/Cargo.toml
+++ b/src/sacp-proxy/Cargo.toml
@@ -13,7 +13,6 @@ agent-client-protocol-schema.workspace = true
 futures.workspace = true
 fxhash.workspace = true
 
-rmcp.workspace = true
 sacp = { version = "1.0.0-alpha.7", path = "../sacp" }
 serde.workspace = true
 serde_json.workspace = true

--- a/src/sacp-rmcp/Cargo.toml
+++ b/src/sacp-rmcp/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "sacp-rmcp"
+version = "0.1.0"
+edition = "2024"
+description = "rmcp integration for SACP proxy components"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/symposium-dev/symposium-acp"
+keywords = ["acp", "agent", "proxy", "mcp", "rmcp"]
+categories = ["development-tools"]
+
+[dependencies]
+sacp = { version = "1.0.0-alpha.7", path = "../sacp" }
+sacp-proxy = { version = "1.0.0-alpha.7", path = "../sacp-proxy" }
+rmcp.workspace = true
+futures.workspace = true
+tokio.workspace = true
+tokio-util.workspace = true
+
+[dev-dependencies]
+serde.workspace = true
+schemars.workspace = true
+tracing-subscriber.workspace = true
+tracing.workspace = true

--- a/src/sacp-rmcp/README.md
+++ b/src/sacp-rmcp/README.md
@@ -1,0 +1,52 @@
+# sacp-rmcp
+
+rmcp integration for SACP proxy components.
+
+## Overview
+
+This crate provides integration between [rmcp](https://docs.rs/rmcp)-based MCP servers and the SACP proxy framework. It allows you to easily add rmcp services to your SACP proxies.
+
+## Usage
+
+Add `sacp-rmcp` to your `Cargo.toml`:
+
+```toml
+[dependencies]
+sacp-proxy = "1.0"
+sacp-rmcp = "0.1"
+rmcp = "0.8"
+```
+
+Then use the extension trait to add rmcp servers to your registry:
+
+```rust
+use sacp_proxy::McpServiceRegistry;
+use sacp_rmcp::McpServiceRegistryRmcpExt;
+
+let registry = McpServiceRegistry::new();
+
+// Add an rmcp-based MCP server
+registry.add_rmcp_server("my-server", || MyRmcpService::new())?;
+
+// Or chain multiple servers
+let registry = McpServiceRegistry::new()
+    .with_rmcp_server("server1", || Service1::new())?
+    .with_rmcp_server("server2", || Service2::new())?;
+```
+
+## Why a Separate Crate?
+
+The `sacp-rmcp` crate is separate from `sacp-proxy` to avoid tying the stable 1.0 `sacp-proxy` API to the 0.x `rmcp` crate. This allows:
+
+- `sacp-proxy` to maintain a stable 1.0 API
+- `sacp-rmcp` to track `rmcp` updates independently
+- Breaking changes in `rmcp` only require updating `sacp-rmcp`, not `sacp-proxy`
+
+## License
+
+Licensed under either of:
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](../../LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+- MIT license ([LICENSE-MIT](../../LICENSE-MIT) or http://opensource.org/licenses/MIT)
+
+at your option.

--- a/src/sacp-rmcp/examples/with_mcp_server.rs
+++ b/src/sacp-rmcp/examples/with_mcp_server.rs
@@ -16,6 +16,7 @@ use rmcp::{
 };
 use sacp::JrHandlerChain;
 use sacp_proxy::{AcpProxyExt, McpServiceRegistry};
+use sacp_rmcp::McpServiceRegistryRmcpExt;
 use serde::{Deserialize, Serialize};
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 

--- a/src/sacp-rmcp/src/lib.rs
+++ b/src/sacp-rmcp/src/lib.rs
@@ -1,0 +1,123 @@
+//! # sacp-rmcp - rmcp integration for SACP
+//!
+//! This crate provides integration between [rmcp](https://docs.rs/rmcp) MCP servers
+//! and the SACP proxy framework.
+//!
+//! ## Usage
+//!
+//! Add rmcp-based MCP servers to your proxy using the extension trait:
+//!
+//! ```ignore
+//! use sacp_proxy::McpServiceRegistry;
+//! use sacp_rmcp::McpServiceRegistryRmcpExt;
+//!
+//! let registry = McpServiceRegistry::new();
+//! registry.add_rmcp_server("my-server", || MyRmcpService::new())?;
+//! ```
+
+use rmcp::ServiceExt;
+use sacp::{ByteStreams, Component};
+use sacp_proxy::McpServiceRegistry;
+use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
+
+/// Extension trait for adding rmcp-based MCP servers to a registry.
+pub trait McpServiceRegistryRmcpExt {
+    /// Add an MCP server implemented using the rmcp crate.
+    ///
+    /// # Parameters
+    ///
+    /// - `name`: The name of the server.
+    /// - `make_service`: A function that creates the service (e.g., `YourService::new`).
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// registry.add_rmcp_server("my-server", || MyRmcpService::new())?;
+    /// ```
+    fn add_rmcp_server<S>(
+        &self,
+        name: impl ToString,
+        make_service: impl Fn() -> S + 'static + Send + Sync,
+    ) -> Result<(), sacp::Error>
+    where
+        S: rmcp::Service<rmcp::RoleServer>;
+
+    /// Add the MCP server to the registry and return `self`. Useful for chaining.
+    /// Equivalent to [`Self::add_rmcp_server`].
+    fn with_rmcp_server<S>(
+        self,
+        name: impl ToString,
+        make_service: impl Fn() -> S + 'static + Send + Sync,
+    ) -> Result<Self, sacp::Error>
+    where
+        S: rmcp::Service<rmcp::RoleServer>,
+        Self: Sized;
+}
+
+impl McpServiceRegistryRmcpExt for McpServiceRegistry {
+    fn add_rmcp_server<S>(
+        &self,
+        name: impl ToString,
+        make_service: impl Fn() -> S + 'static + Send + Sync,
+    ) -> Result<(), sacp::Error>
+    where
+        S: rmcp::Service<rmcp::RoleServer>,
+    {
+        self.add_mcp_server(name, move || {
+            let service = make_service();
+            RmcpServerComponent { service }
+        })
+    }
+
+    fn with_rmcp_server<S>(
+        self,
+        name: impl ToString,
+        make_service: impl Fn() -> S + 'static + Send + Sync,
+    ) -> Result<Self, sacp::Error>
+    where
+        S: rmcp::Service<rmcp::RoleServer>,
+    {
+        self.add_rmcp_server(name, make_service)?;
+        Ok(self)
+    }
+}
+
+/// Component wrapper for rmcp services
+struct RmcpServerComponent<S> {
+    service: S,
+}
+
+impl<S> Component for RmcpServerComponent<S>
+where
+    S: rmcp::Service<rmcp::RoleServer>,
+{
+    async fn serve(self, client: impl Component) -> Result<(), sacp::Error> {
+        // Create tokio byte streams that rmcp expects
+        let (mcp_server_stream, mcp_client_stream) = tokio::io::duplex(8192);
+        let (mcp_server_read, mcp_server_write) = tokio::io::split(mcp_server_stream);
+        let (mcp_client_read, mcp_client_write) = tokio::io::split(mcp_client_stream);
+
+        // Create ByteStreams component for the client side
+        let byte_streams =
+            ByteStreams::new(mcp_client_write.compat_write(), mcp_client_read.compat());
+
+        // Spawn task to connect byte_streams to the provided client
+        tokio::spawn(async move {
+            let _ = byte_streams.serve(client).await;
+        });
+
+        // Run the rmcp server with the server side of the duplex stream
+        let running_server = self
+            .service
+            .serve((mcp_server_read, mcp_server_write))
+            .await
+            .map_err(sacp::Error::into_internal_error)?;
+
+        // Wait for the server to finish
+        running_server
+            .waiting()
+            .await
+            .map(|_quit_reason| ())
+            .map_err(sacp::Error::into_internal_error)
+    }
+}


### PR DESCRIPTION
BREAKING CHANGE: McpServiceRegistry.add_rmcp_server() and with_rmcp_server() methods have been moved to the sacp-rmcp crate. Users must now import McpServiceRegistryRmcpExt trait from sacp-rmcp to use these methods.

This change removes the rmcp 0.8 dependency from sacp-proxy 1.0, allowing the rmcp integration to evolve independently. The base MCP server API now uses the Component trait via add_mcp_server(), which works with any Component implementation.

- Remove rmcp dependency from sacp-proxy
- Create new sacp-rmcp crate for rmcp integration
- Add SpawnMcpServer trait as factory pattern for DynComponent instances
- Use DynComponent for type-erased Component handling
- Move with_mcp_server example to sacp-rmcp
- Update sacp-conductor tests to use sacp-rmcp extension trait