### PR TITLE
chore: release

### DIFF
--- a/src/elizacp/CHANGELOG.md
+++ b/src/elizacp/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.0-alpha.9](https://github.com/symposium-dev/symposium-acp/compare/elizacp-v1.0.0-alpha.8...elizacp-v1.0.0-alpha.9) - 2025-11-13
+## [1.0.0](https://github.com/symposium-dev/symposium-acp/compare/elizacp-v1.0.0-alpha.8...elizacp-v1.0.0) - 2025-11-13
 
 ### Other
 

--- a/src/elizacp/Cargo.toml
+++ b/src/elizacp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elizacp"
-version = "1.0.0-alpha.9"
+version = "1.0.0"
 edition = "2024"
 description = "Classic Eliza chatbot as an ACP agent for testing"
 license = "MIT OR Apache-2.0"
@@ -15,7 +15,7 @@ name = "elizacp"
 path = "src/main.rs"
 
 [dependencies]
-sacp = { version = "1.0.0-alpha.8", path = "../sacp" }
+sacp = { version = "1.0.0", path = "../sacp" }
 agent-client-protocol-schema.workspace = true
 anyhow.workspace = true
 clap.workspace = true
@@ -29,7 +29,7 @@ tokio-util.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 uuid.workspace = true
-sacp-tokio = { version = "1.0.0-alpha.9", path = "../sacp-tokio" }
+sacp-tokio = { version = "1.0.0", path = "../sacp-tokio" }
 
 [dev-dependencies]
 expect-test.workspace = true

--- a/src/sacp-conductor/CHANGELOG.md
+++ b/src/sacp-conductor/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.0-alpha.10](https://github.com/symposium-dev/symposium-acp/compare/sacp-conductor-v1.0.0-alpha.9...sacp-conductor-v1.0.0-alpha.10) - 2025-11-13
+## [1.0.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-conductor-v1.0.0-alpha.9...sacp-conductor-v1.0.0) - 2025-11-13
 
 ### Other
 

--- a/src/sacp-conductor/Cargo.toml
+++ b/src/sacp-conductor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-conductor"
-version = "1.0.0-alpha.10"
+version = "1.0.0"
 edition = "2024"
 description = "Conductor for orchestrating SACP proxy chains"
 license = "MIT OR Apache-2.0"
@@ -12,9 +12,9 @@ categories = ["development-tools"]
 test-support = []
 
 [dependencies]
-sacp = { version = "1.0.0-alpha.8", path = "../sacp" }
-sacp-proxy = { version = "1.0.0-alpha.8", path = "../sacp-proxy" }
-sacp-tokio = { version = "1.0.0-alpha.9", path = "../sacp-tokio" }
+sacp = { version = "1.0.0", path = "../sacp" }
+sacp-proxy = { version = "1.0.0", path = "../sacp-proxy" }
+sacp-tokio = { version = "1.0.0", path = "../sacp-tokio" }
 agent-client-protocol-schema.workspace = true
 anyhow.workspace = true
 chrono.workspace = true

--- a/src/sacp-proxy/CHANGELOG.md
+++ b/src/sacp-proxy/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.0-alpha.8](https://github.com/symposium-dev/symposium-acp/compare/sacp-proxy-v1.0.0-alpha.7...sacp-proxy-v1.0.0-alpha.8) - 2025-11-13
+## [1.0.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-proxy-v1.0.0-alpha.7...sacp-proxy-v1.0.0) - 2025-11-13
 
 ### Other
 

--- a/src/sacp-proxy/Cargo.toml
+++ b/src/sacp-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-proxy"
-version = "1.0.0-alpha.8"
+version = "1.0.0"
 edition = "2024"
 description = "Framework for building SACP proxy components"
 license = "MIT OR Apache-2.0"
@@ -13,7 +13,7 @@ agent-client-protocol-schema.workspace = true
 futures.workspace = true
 fxhash.workspace = true
 
-sacp = { version = "1.0.0-alpha.8", path = "../sacp" }
+sacp = { version = "1.0.0", path = "../sacp" }
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true

--- a/src/sacp-rmcp/CHANGELOG.md
+++ b/src/sacp-rmcp/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.1](https://github.com/symposium-dev/symposium-acp/compare/sacp-rmcp-v0.1.0...sacp-rmcp-v0.1.1) - 2025-11-14
+## [0.8.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-rmcp-v0.1.0...sacp-rmcp-v0.8.0) - 2025-11-14
 
 ### Other
 

--- a/src/sacp-rmcp/Cargo.toml
+++ b/src/sacp-rmcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-rmcp"
-version = "0.1.1"
+version = "0.8.0"
 edition = "2024"
 description = "rmcp integration for SACP proxy components"
 license = "MIT OR Apache-2.0"
@@ -9,8 +9,8 @@ keywords = ["acp", "agent", "proxy", "mcp", "rmcp"]
 categories = ["development-tools"]
 
 [dependencies]
-sacp = { version = "1.0.0-alpha.8", path = "../sacp" }
-sacp-proxy = { version = "1.0.0-alpha.8", path = "../sacp-proxy" }
+sacp = { version = "1.0.0", path = "../sacp" }
+sacp-proxy = { version = "1.0.0", path = "../sacp-proxy" }
 rmcp.workspace = true
 futures.workspace = true
 tokio.workspace = true

--- a/src/sacp-test/CHANGELOG.md
+++ b/src/sacp-test/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.0-alpha.1](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-test-v1.0.0-alpha.1) - 2025-11-05
+## [1.0.0](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-test-v1.0.0) - 2025-11-05
 
 ### Added
 

--- a/src/sacp-test/Cargo.toml
+++ b/src/sacp-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-test"
-version = "1.0.0-alpha.1"
+version = "1.0.0"
 edition = "2024"
 
 [dependencies]

--- a/src/sacp-tokio/CHANGELOG.md
+++ b/src/sacp-tokio/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.0-alpha.9](https://github.com/symposium-dev/symposium-acp/compare/sacp-tokio-v1.0.0-alpha.8...sacp-tokio-v1.0.0-alpha.9) - 2025-11-13
+## [1.0.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-tokio-v1.0.0-alpha.8...sacp-tokio-v1.0.0) - 2025-11-13
 
 ### Other
 

--- a/src/sacp-tokio/Cargo.toml
+++ b/src/sacp-tokio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-tokio"
-version = "1.0.0-alpha.9"
+version = "1.0.0"
 edition = "2024"
 description = "Tokio-based utilities for SACP (Symposium's extensions to ACP)"
 license = "MIT OR Apache-2.0"
@@ -9,7 +9,7 @@ keywords = ["acp", "agent", "protocol", "ai", "tokio"]
 categories = ["development-tools"]
 
 [dependencies]
-sacp = { version = "1.0.0-alpha.8", path = "../sacp" }
+sacp = { version = "1.0.0", path = "../sacp" }
 futures.workspace = true
 
 serde.workspace = true

--- a/src/sacp/CHANGELOG.md
+++ b/src/sacp/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.0-alpha.8](https://github.com/symposium-dev/symposium-acp/compare/sacp-v1.0.0-alpha.7...sacp-v1.0.0-alpha.8) - 2025-11-13
+## [1.0.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-v1.0.0-alpha.7...sacp-v1.0.0) - 2025-11-13
 
 ### Fixed
 

--- a/src/sacp/Cargo.toml
+++ b/src/sacp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp"
-version = "1.0.0-alpha.8"
+version = "1.0.0"
 edition = "2024"
 description = "Core protocol types and traits for SACP (Symposium's extensions to ACP)"
 license = "MIT OR Apache-2.0"

--- a/src/yopo/CHANGELOG.md
+++ b/src/yopo/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.0-alpha.9](https://github.com/symposium-dev/symposium-acp/compare/yopo-v1.0.0-alpha.8...yopo-v1.0.0-alpha.9) - 2025-11-13
+## [1.0.0](https://github.com/symposium-dev/symposium-acp/compare/yopo-v1.0.0-alpha.8...yopo-v1.0.0) - 2025-11-13
 
 ### Other
 

--- a/src/yopo/Cargo.toml
+++ b/src/yopo/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "yopo"
-version = "1.0.0-alpha.9"
+version = "1.0.0"
 edition = "2024"
 description = "YOPO (You Only Prompt Once) - A simple ACP client for one-shot prompts"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/symposium-dev/symposium-acp"
 
 [dependencies]
-sacp = { version = "1.0.0-alpha.8", path = "../sacp" }
-sacp-tokio = { version = "1.0.0-alpha.9", path = "../sacp-tokio" }
+sacp = { version = "1.0.0", path = "../sacp" }
+sacp-tokio = { version = "1.0.0", path = "../sacp-tokio" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }


### PR DESCRIPTION



## 🤖 New release

* `sacp-test`: 1.0.0-alpha.1
* `sacp-rmcp`: 0.1.0 -> 0.1.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `sacp-test`

<blockquote>

## [1.0.0-alpha.1](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-test-v1.0.0-alpha.1) - 2025-11-05

### Added

- *(sacp-test)* add arrow proxy for testing

### Other

- update all versions from 1.0.0-alpha to 1.0.0-alpha.1
- release v1.0.0-alpha
- *(conductor)* add integration test with arrow proxy and eliza
- *(conductor)* add integration test with arrow proxy and eliza
- rename sacp-doc-test to sacp-test
</blockquote>

## `sacp-rmcp`

<blockquote>

## [0.1.1](https://github.com/symposium-dev/symposium-acp/compare/sacp-rmcp-v0.1.0...sacp-rmcp-v0.1.1) - 2025-11-14

### Other

- release
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).