### PR TITLE
chore: release

### DIFF
--- a/src/sacp-conductor/CHANGELOG.md
+++ b/src/sacp-conductor/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1](https://github.com/symposium-dev/symposium-acp/compare/sacp-conductor-v1.0.0...sacp-conductor-v1.0.1) - 2025-11-15
+
+### Other
+
+- updated the following local packages: sacp-proxy
+
 ## [1.0.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-conductor-v1.0.0-alpha.9...sacp-conductor-v1.0.0) - 2025-11-13
 
 ### Other

--- a/src/sacp-conductor/Cargo.toml
+++ b/src/sacp-conductor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-conductor"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2024"
 description = "Conductor for orchestrating SACP proxy chains"
 license = "MIT OR Apache-2.0"
@@ -13,7 +13,7 @@ test-support = []
 
 [dependencies]
 sacp = { version = "1.0.0", path = "../sacp" }
-sacp-proxy = { version = "1.0.0", path = "../sacp-proxy" }
+sacp-proxy = { version = "1.1.0", path = "../sacp-proxy" }
 sacp-tokio = { version = "1.0.0", path = "../sacp-tokio" }
 agent-client-protocol-schema.workspace = true
 anyhow.workspace = true

--- a/src/sacp-proxy/CHANGELOG.md
+++ b/src/sacp-proxy/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-proxy-v1.0.0...sacp-proxy-v1.1.0) - 2025-11-15
+
+### Added
+
+- *(sacp-proxy)* add add_registered_mcp_servers_to public method
+
+### Fixed
+
+- *(sacp-proxy)* allow handlers after provide_mcp to see modified NewSessionRequest
+
+### Other
+
+- *(sacp-proxy)* use MatchMessage for cleaner message handling
+- *(sacp-proxy)* use else-if-let chains in McpServiceRegistry::handle_message
+
 ## [1.0.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-proxy-v1.0.0-alpha.7...sacp-proxy-v1.0.0) - 2025-11-13
 
 ### Other

--- a/src/sacp-proxy/Cargo.toml
+++ b/src/sacp-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-proxy"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2024"
 description = "Framework for building SACP proxy components"
 license = "MIT OR Apache-2.0"

--- a/src/sacp-rmcp/CHANGELOG.md
+++ b/src/sacp-rmcp/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.1](https://github.com/symposium-dev/symposium-acp/compare/sacp-rmcp-v0.8.0...sacp-rmcp-v0.8.1) - 2025-11-15
+
+### Other
+
+- updated the following local packages: sacp-proxy
+
 ## [0.8.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-rmcp-v0.1.0...sacp-rmcp-v0.8.0) - 2025-11-14
 
 ### Other

--- a/src/sacp-rmcp/Cargo.toml
+++ b/src/sacp-rmcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-rmcp"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 description = "rmcp integration for SACP proxy components"
 license = "MIT OR Apache-2.0"
@@ -10,7 +10,7 @@ categories = ["development-tools"]
 
 [dependencies]
 sacp = { version = "1.0.0", path = "../sacp" }
-sacp-proxy = { version = "1.0.0", path = "../sacp-proxy" }
+sacp-proxy = { version = "1.1.0", path = "../sacp-proxy" }
 rmcp.workspace = true
 futures.workspace = true
 tokio.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `sacp-proxy`: 1.0.0 -> 1.1.0 (✓ API compatible changes)
* `sacp-test`: 1.0.0
* `sacp-conductor`: 1.0.0 -> 1.0.1
* `sacp-rmcp`: 0.8.0 -> 0.8.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `sacp-proxy`

<blockquote>

## [1.1.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-proxy-v1.0.0...sacp-proxy-v1.1.0) - 2025-11-15

### Added

- *(sacp-proxy)* add add_registered_mcp_servers_to public method

### Fixed

- *(sacp-proxy)* allow handlers after provide_mcp to see modified NewSessionRequest

### Other

- *(sacp-proxy)* use MatchMessage for cleaner message handling
- *(sacp-proxy)* use else-if-let chains in McpServiceRegistry::handle_message
</blockquote>

## `sacp-test`

<blockquote>

## [1.0.0](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-test-v1.0.0) - 2025-11-05

### Added

- *(sacp-test)* add arrow proxy for testing

### Other

- update all versions from 1.0.0-alpha to 1.0.0-alpha.1
- release v1.0.0-alpha
- *(conductor)* add integration test with arrow proxy and eliza
- *(conductor)* add integration test with arrow proxy and eliza
- rename sacp-doc-test to sacp-test
</blockquote>

## `sacp-conductor`

<blockquote>

## [1.0.1](https://github.com/symposium-dev/symposium-acp/compare/sacp-conductor-v1.0.0...sacp-conductor-v1.0.1) - 2025-11-15

### Other

- updated the following local packages: sacp-proxy
</blockquote>

## `sacp-rmcp`

<blockquote>

## [0.8.1](https://github.com/symposium-dev/symposium-acp/compare/sacp-rmcp-v0.8.0...sacp-rmcp-v0.8.1) - 2025-11-15

### Other

- updated the following local packages: sacp-proxy
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).