### PR TITLE
chore: release

### DIFF
--- a/src/sacp-conductor/CHANGELOG.md
+++ b/src/sacp-conductor/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.1](https://github.com/symposium-dev/symposium-acp/compare/sacp-conductor-v2.0.0...sacp-conductor-v2.0.1) - 2025-11-18
+
+### Other
+
+- *(yopo)* accept impl ToString for prompt parameter
+- replace yolo_prompt with direct yopo::prompt calls
+- upgrade to sacp-proxy 2.0.0 and migrate tests to McpServer API
+
 ## [2.0.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-conductor-v1.0.1...sacp-conductor-v2.0.0) - 2025-11-17
 
 ### Added

--- a/src/sacp-conductor/Cargo.toml
+++ b/src/sacp-conductor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-conductor"
-version = "2.0.0"
+version = "2.0.1"
 edition = "2024"
 description = "Conductor for orchestrating SACP proxy chains"
 license = "MIT OR Apache-2.0"

--- a/src/yopo/CHANGELOG.md
+++ b/src/yopo/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0](https://github.com/symposium-dev/symposium-acp/compare/yopo-v1.0.0...yopo-v1.1.0) - 2025-11-18
+
+### Added
+
+- *(yopo)* add library API with callback support for testing SACP agents
+
+### Fixed
+
+- *(yopo)* correct doctest examples to use valid AcpAgent API
+
+### Other
+
+- *(yopo)* simplify callback implementation using AsyncFnMut
+- *(yopo)* accept impl ToString for prompt parameter
+- *(yopo)* return sacp::Error instead of Box<dyn Error>
+
 ## [1.0.0](https://github.com/symposium-dev/symposium-acp/compare/yopo-v1.0.0-alpha.8...yopo-v1.0.0) - 2025-11-13
 
 ### Other

--- a/src/yopo/Cargo.toml
+++ b/src/yopo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yopo"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2024"
 description = "YOPO (You Only Prompt Once) - A simple ACP client for one-shot prompts"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `yopo`: 1.0.0 -> 1.1.0 (✓ API compatible changes)
* `sacp-test`: 1.0.0
* `sacp-conductor`: 2.0.0 -> 2.0.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `yopo`

<blockquote>

## [1.1.0](https://github.com/symposium-dev/symposium-acp/compare/yopo-v1.0.0...yopo-v1.1.0) - 2025-11-18

### Added

- *(yopo)* add library API with callback support for testing SACP agents

### Fixed

- *(yopo)* correct doctest examples to use valid AcpAgent API

### Other

- *(yopo)* simplify callback implementation using AsyncFnMut
- *(yopo)* accept impl ToString for prompt parameter
- *(yopo)* return sacp::Error instead of Box<dyn Error>
</blockquote>

## `sacp-test`

<blockquote>

## [1.0.0](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-test-v1.0.0) - 2025-11-05

### Added

- *(sacp-test)* add arrow proxy for testing

### Other

- update all versions from 1.0.0-alpha to 1.0.0-alpha.1
- release v1.0.0-alpha
- *(conductor)* add integration test with arrow proxy and eliza
- *(conductor)* add integration test with arrow proxy and eliza
- rename sacp-doc-test to sacp-test
</blockquote>

## `sacp-conductor`

<blockquote>

## [2.0.1](https://github.com/symposium-dev/symposium-acp/compare/sacp-conductor-v2.0.0...sacp-conductor-v2.0.1) - 2025-11-18

### Other

- *(yopo)* accept impl ToString for prompt parameter
- replace yolo_prompt with direct yopo::prompt calls
- upgrade to sacp-proxy 2.0.0 and migrate tests to McpServer API
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).