### PR TITLE
refactor(elizacp): export ElizaAgent as public Component

### DIFF
--- a/src/elizacp/src/main.rs
+++ b/src/elizacp/src/main.rs
@@ -36,7 +36,8 @@
 
 use anyhow::Result;
 use clap::Parser;
-use elizacp::run_elizacp;
+use elizacp::ElizaAgent;
+use sacp::Component;
 use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitExt};
 
 #[derive(Parser, Debug)]
@@ -70,7 +71,7 @@ async fn main() -> Result<()> {
     tracing::info!("Elizacp starting");
 
     // Run the Eliza agent
-    run_elizacp(sacp_tokio::Stdio::new()).await?;
+    ElizaAgent::new().serve(sacp_tokio::Stdio::new()).await?;
 
     Ok(())
 }

--- a/src/elizacp/tests/mcp_tool_invocation.rs
+++ b/src/elizacp/tests/mcp_tool_invocation.rs
@@ -1,12 +1,12 @@
 //! Integration tests for elizacp MCP tool invocation
 
-use elizacp::run_elizacp;
+use elizacp::ElizaAgent;
 use expect_test::expect;
-use sacp::JrHandlerChain;
 use sacp::schema::{
     ContentBlock, InitializeRequest, McpServer, NewSessionRequest, PromptRequest,
     SessionNotification, TextContent,
 };
+use sacp::{Component, JrHandlerChain};
 use std::path::PathBuf;
 
 /// Test helper to receive a JSON-RPC response
@@ -47,11 +47,12 @@ async fn test_elizacp_mcp_tool_call() -> Result<(), sacp::Error> {
             }
         })
         .with_spawned(|_cx| async move {
-            run_elizacp(sacp::ByteStreams::new(
-                elizacp_out.compat_write(),
-                elizacp_in.compat(),
-            ))
-            .await
+            ElizaAgent::new()
+                .serve(sacp::ByteStreams::new(
+                    elizacp_out.compat_write(),
+                    elizacp_in.compat(),
+                ))
+                .await
         })
         .with_client(transport, async |client_cx| {
             // Initialize

--- a/src/sacp-conductor/tests/empty_conductor_eliza.rs
+++ b/src/sacp-conductor/tests/empty_conductor_eliza.rs
@@ -31,7 +31,7 @@ struct MockEliza;
 
 impl Component for MockEliza {
     async fn serve(self, client: impl Component) -> Result<(), sacp::Error> {
-        elizacp::run_elizacp(client).await
+        elizacp::ElizaAgent::new().serve(client).await
     }
 }
 

--- a/src/sacp-conductor/tests/nested_conductor.rs
+++ b/src/sacp-conductor/tests/nested_conductor.rs
@@ -41,7 +41,7 @@ struct MockEliza;
 
 impl Component for MockEliza {
     async fn serve(self, client: impl Component) -> Result<(), sacp::Error> {
-        elizacp::run_elizacp(client).await
+        elizacp::ElizaAgent::new().serve(client).await
     }
 }
 

--- a/src/sacp-conductor/tests/test_session_id_in_mcp_tools.rs
+++ b/src/sacp-conductor/tests/test_session_id_in_mcp_tools.rs
@@ -92,7 +92,7 @@ impl Component for ElizacpAgentComponent {
 
         // Spawn elizacp in a background task
         tokio::spawn(async move {
-            if let Err(e) = elizacp::run_elizacp(elizacp_transport).await {
+            if let Err(e) = elizacp::ElizaAgent::new().serve(elizacp_transport).await {
                 tracing::error!("Elizacp error: {}", e);
             }
         });


### PR DESCRIPTION
## Summary

This PR refactors  to export a public `ElizaAgent` component that implements the `Component` trait, replacing the previous `run_elizacp` function.

## Motivation

The previous API required calling `run_elizacp(transport)`, which was less composable. By implementing `Component` directly on `ElizaAgent`, it can be used more naturally in component chains and is consistent with other components in the codebase.

## Changes

- Made `ElizaAgent` struct and `ElizaAgent::new()` public
- Implemented `Component` trait for `ElizaAgent`
- Removed `run_elizacp` function
- Updated `main.rs` to use `ElizaAgent::new().serve(transport)`
- Updated all test files to use the new API

## Usage

**Before:**
```rust
run_elizacp(transport).await?;
```

**After:**
```rust
ElizaAgent::new().serve(transport).await?;
```

## Testing

All existing tests pass with the new API:
- `cargo test -p elizacp` ✅
- `cargo test -p sacp-conductor --test empty_conductor_eliza` ✅
- `cargo test -p sacp-conductor --test nested_conductor` ✅
- `cargo test -p sacp-conductor --test test_session_id_in_mcp_tools` ✅