### PR TITLE
chore: release

### DIFF
--- a/src/elizacp/CHANGELOG.md
+++ b/src/elizacp/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.1](https://github.com/symposium-dev/symposium-acp/compare/elizacp-v2.0.0...elizacp-v2.0.1) - 2025-11-23
+
+### Fixed
+
+- *(elizacp)* support hyphens in MCP server and tool names
+
 ## [2.0.0](https://github.com/symposium-dev/symposium-acp/compare/elizacp-v1.2.0...elizacp-v2.0.0) - 2025-11-23
 
 ### Other

--- a/src/elizacp/Cargo.toml
+++ b/src/elizacp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elizacp"
-version = "2.0.0"
+version = "2.0.1"
 edition = "2024"
 description = "Classic Eliza chatbot as an ACP agent for testing"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `sacp-test`: 1.0.0
* `elizacp`: 2.0.0 -> 2.0.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `sacp-test`

<blockquote>

## [1.0.0](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-test-v1.0.0) - 2025-11-05

### Added

- *(sacp-test)* add arrow proxy for testing

### Other

- update all versions from 1.0.0-alpha to 1.0.0-alpha.1
- release v1.0.0-alpha
- *(conductor)* add integration test with arrow proxy and eliza
- *(conductor)* add integration test with arrow proxy and eliza
- rename sacp-doc-test to sacp-test
</blockquote>

## `elizacp`

<blockquote>

## [2.0.1](https://github.com/symposium-dev/symposium-acp/compare/elizacp-v2.0.0...elizacp-v2.0.1) - 2025-11-23

### Fixed

- *(elizacp)* support hyphens in MCP server and tool names
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).