### PR TITLE
chore!: bump elizacp and sacp-conductor to 3.0.0

### DIFF
--- a/src/elizacp/Cargo.toml
+++ b/src/elizacp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elizacp"
-version = "2.0.1"
+version = "3.0.0"
 edition = "2024"
 description = "Classic Eliza chatbot as an ACP agent for testing"
 license = "MIT OR Apache-2.0"

--- a/src/sacp-conductor/Cargo.toml
+++ b/src/sacp-conductor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-conductor"
-version = "2.1.1"
+version = "3.0.0"
 edition = "2024"
 description = "Conductor for orchestrating SACP proxy chains"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary

Bumps `elizacp` and `sacp-conductor` to major version 3.0.0 to correctly reflect breaking API changes that cargo-semver-checks missed.

## Breaking Changes

### elizacp 2.0.1 → 3.0.0
- **Removed `run_elizacp()` function** - The standalone function was replaced with `ElizaAgent` struct that implements the `Component` trait directly

### sacp-conductor 2.1.1 → 3.0.0  
- **`ConductorArgs::run()` is now private** - Use `ConductorArgs::main()` as the public entry point
- **New required debug logging infrastructure** - `run()` now takes a `debug_logger` parameter internally

## Why This Is Needed

PR #58 (release-plz automation) proposed minor/patch bumps for these crates, but the API changes are breaking:
- Removing a public function (`run_elizacp`) breaks downstream code
- Changing method visibility (`run` → private) breaks downstream code

This PR should be merged before or alongside PR #58 to ensure correct semver.