### PR TITLE
chore: release

### DIFF
--- a/src/elizacp/CHANGELOG.md
+++ b/src/elizacp/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.2](https://github.com/symposium-dev/symposium-acp/compare/elizacp-v3.0.1...elizacp-v3.0.2) - 2025-11-29
+
+### Other
+
+- updated the following local packages: sacp, sacp-tokio
+
 ## [3.0.1](https://github.com/symposium-dev/symposium-acp/compare/elizacp-v3.0.0...elizacp-v3.0.1) - 2025-11-25
 
 ### Fixed

--- a/src/elizacp/Cargo.toml
+++ b/src/elizacp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elizacp"
-version = "3.0.1"
+version = "3.0.2"
 edition = "2024"
 description = "Classic Eliza chatbot as an ACP agent for testing"
 license = "MIT OR Apache-2.0"
@@ -15,7 +15,7 @@ name = "elizacp"
 path = "src/main.rs"
 
 [dependencies]
-sacp = { version = "1.1.1", path = "../sacp" }
+sacp = { version = "2.0.0", path = "../sacp" }
 agent-client-protocol-schema.workspace = true
 anyhow.workspace = true
 clap.workspace = true
@@ -30,7 +30,7 @@ tokio-util.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 uuid.workspace = true
-sacp-tokio = { version = "2.0.1", path = "../sacp-tokio" }
+sacp-tokio = { version = "2.1.0", path = "../sacp-tokio" }
 
 [dev-dependencies]
 expect-test.workspace = true

--- a/src/sacp-conductor/CHANGELOG.md
+++ b/src/sacp-conductor/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-conductor-v3.0.0...sacp-conductor-v4.0.0) - 2025-11-29
+
+### Added
+
+- *(sacp)* make trace functions generic over MessageAndCx<R, N>
+- *(conductor)* add relative timestamps to debug log output
+- *(conductor)* add HTTP request UUIDs for tracing
+- *(mcp-bridge)* add detailed logging for HTTP message buffering
+- *(trace-viewer)* add live trace viewing with --serve flag
+- *(conductor)* add trace snapshot test and fix initialize response tracing
+- *(conductor)* add trace event system with WriteEvent trait
+- *(conductor)* add trace event logging for sequence diagram visualization
+
+### Fixed
+
+- *(conductor)* restore test_session_id_in_mcp_tools to use yopo and acp_url
+- *(conductor)* relax session_id test assertion for early MCP calls
+- *(conductor)* relax session_id test assertion for early MCP calls
+- buffer outgoing messages until HTTP connection is established
+
+### Other
+
+- *(conductor)* improve MCP-over-ACP message tracing
+
 ## [3.0.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-conductor-v2.1.1...sacp-conductor-v3.0.0) - 2025-11-25
 
 ### Added

--- a/src/sacp-conductor/Cargo.toml
+++ b/src/sacp-conductor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-conductor"
-version = "3.0.0"
+version = "4.0.0"
 edition = "2024"
 description = "Conductor for orchestrating SACP proxy chains"
 license = "MIT OR Apache-2.0"
@@ -12,9 +12,9 @@ categories = ["development-tools"]
 test-support = []
 
 [dependencies]
-sacp = { version = "1.1.1", path = "../sacp" }
-sacp-proxy = { version = "2.0.2", path = "../sacp-proxy" }
-sacp-tokio = { version = "2.0.1", path = "../sacp-tokio" }
+sacp = { version = "2.0.0", path = "../sacp" }
+sacp-proxy = { version = "3.0.0", path = "../sacp-proxy" }
+sacp-tokio = { version = "2.1.0", path = "../sacp-tokio" }
 sacp-trace-viewer = { version = "0.1.0", path = "../sacp-trace-viewer" }
 agent-client-protocol-schema.workspace = true
 anyhow.workspace = true

--- a/src/sacp-proxy/CHANGELOG.md
+++ b/src/sacp-proxy/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-proxy-v2.0.2...sacp-proxy-v3.0.0) - 2025-11-29
+
+### Added
+
+- [**breaking**] change JrMessage trait to take &self and require Clone
+
+### Fixed
+
+- *(conductor)* relax session_id test assertion for early MCP calls
+
 ## [2.0.2](https://github.com/symposium-dev/symposium-acp/compare/sacp-proxy-v2.0.1...sacp-proxy-v2.0.2) - 2025-11-25
 
 ### Other

--- a/src/sacp-proxy/Cargo.toml
+++ b/src/sacp-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-proxy"
-version = "2.0.2"
+version = "3.0.0"
 edition = "2024"
 description = "Framework for building SACP proxy components"
 license = "MIT OR Apache-2.0"
@@ -13,7 +13,7 @@ agent-client-protocol-schema.workspace = true
 futures.workspace = true
 fxhash.workspace = true
 
-sacp = { version = "1.1.1", path = "../sacp" }
+sacp = { version = "2.0.0", path = "../sacp" }
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true

--- a/src/sacp-rmcp/CHANGELOG.md
+++ b/src/sacp-rmcp/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.5](https://github.com/symposium-dev/symposium-acp/compare/sacp-rmcp-v0.8.4...sacp-rmcp-v0.8.5) - 2025-11-29
+
+### Other
+
+- updated the following local packages: sacp, sacp-proxy
+
 ## [0.8.4](https://github.com/symposium-dev/symposium-acp/compare/sacp-rmcp-v0.8.3...sacp-rmcp-v0.8.4) - 2025-11-25
 
 ### Other

--- a/src/sacp-rmcp/Cargo.toml
+++ b/src/sacp-rmcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-rmcp"
-version = "0.8.4"
+version = "0.8.5"
 edition = "2024"
 description = "rmcp integration for SACP proxy components"
 license = "MIT OR Apache-2.0"
@@ -9,8 +9,8 @@ keywords = ["acp", "agent", "proxy", "mcp", "rmcp"]
 categories = ["development-tools"]
 
 [dependencies]
-sacp = { version = "1.1.1", path = "../sacp" }
-sacp-proxy = { version = "2.0.2", path = "../sacp-proxy" }
+sacp = { version = "2.0.0", path = "../sacp" }
+sacp-proxy = { version = "3.0.0", path = "../sacp-proxy" }
 rmcp.workspace = true
 futures.workspace = true
 tokio.workspace = true

--- a/src/sacp-tee/CHANGELOG.md
+++ b/src/sacp-tee/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/symposium-dev/symposium-acp/compare/sacp-tee-v0.1.2...sacp-tee-v0.1.3) - 2025-11-29
+
+### Other
+
+- updated the following local packages: sacp, sacp-proxy, sacp-tokio
+
 ## [0.1.2](https://github.com/symposium-dev/symposium-acp/compare/sacp-tee-v0.1.1...sacp-tee-v0.1.2) - 2025-11-22
 
 ### Added

--- a/src/sacp-tee/Cargo.toml
+++ b/src/sacp-tee/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-tee"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 description = "A debugging proxy that logs all ACP traffic to a file"
 license = "MIT OR Apache-2.0"
@@ -12,9 +12,9 @@ categories = ["development-tools", "development-tools::debugging"]
 anyhow.workspace = true
 chrono.workspace = true
 clap = { workspace = true, features = ["derive"] }
-sacp = { version = "1.1", path = "../sacp" }
-sacp-proxy = { version = "2.0", path = "../sacp-proxy" }
-sacp-tokio = { version = "2.0", path = "../sacp-tokio" }
+sacp = { version = "2.0", path = "../sacp" }
+sacp-proxy = { version = "3.0", path = "../sacp-proxy" }
+sacp-tokio = { version = "2.1", path = "../sacp-tokio" }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 tokio = { workspace = true, features = ["full"] }

--- a/src/sacp-tokio/CHANGELOG.md
+++ b/src/sacp-tokio/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-tokio-v2.0.1...sacp-tokio-v2.1.0) - 2025-11-29
+
+### Added
+
+- *(yopo)* accept multiple command arguments with env var support
+
 ## [2.0.1](https://github.com/symposium-dev/symposium-acp/compare/sacp-tokio-v2.0.0...sacp-tokio-v2.0.1) - 2025-11-25
 
 ### Other

--- a/src/sacp-tokio/Cargo.toml
+++ b/src/sacp-tokio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-tokio"
-version = "2.0.1"
+version = "2.1.0"
 edition = "2024"
 description = "Tokio-based utilities for SACP (Symposium's extensions to ACP)"
 license = "MIT OR Apache-2.0"
@@ -9,7 +9,7 @@ keywords = ["acp", "agent", "protocol", "ai", "tokio"]
 categories = ["development-tools"]
 
 [dependencies]
-sacp = { version = "1.1.1", path = "../sacp" }
+sacp = { version = "2.0.0", path = "../sacp" }
 futures.workspace = true
 
 serde.workspace = true

--- a/src/sacp-trace-viewer/CHANGELOG.md
+++ b/src/sacp-trace-viewer/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-trace-viewer-v0.1.0) - 2025-11-29
+
+### Added
+
+- *(trace-viewer)* add live trace viewing with --serve flag
+- *(trace-viewer)* add content previews for prompts and session updates
+- *(trace-viewer)* show delta times on all component timelines
+- *(trace-viewer)* add content preview, width slider, and delta times
+- *(trace-viewer)* add rainbow colors, request/response linking, and improved UI
+- *(conductor)* add trace event system with WriteEvent trait

--- a/src/sacp/CHANGELOG.md
+++ b/src/sacp/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-v1.1.1...sacp-v2.0.0) - 2025-11-29
+
+### Added
+
+- *(sacp)* make trace functions generic over MessageAndCx<R, N>
+- [**breaking**] change JrMessage trait to take &self and require Clone
+- *(conductor)* add trace event logging for sequence diagram visualization
+
 ## [1.1.1](https://github.com/symposium-dev/symposium-acp/compare/sacp-v1.1.0...sacp-v1.1.1) - 2025-11-25
 
 ### Other

--- a/src/sacp/Cargo.toml
+++ b/src/sacp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp"
-version = "1.1.1"
+version = "2.0.0"
 edition = "2024"
 description = "Core protocol types and traits for SACP (Symposium's extensions to ACP)"
 license = "MIT OR Apache-2.0"

--- a/src/yopo/CHANGELOG.md
+++ b/src/yopo/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0](https://github.com/symposium-dev/symposium-acp/compare/yopo-v1.2.1...yopo-v1.3.0) - 2025-11-29
+
+### Added
+
+- *(yopo)* accept multiple command arguments with env var support
+
 ## [1.2.1](https://github.com/symposium-dev/symposium-acp/compare/yopo-v1.2.0...yopo-v1.2.1) - 2025-11-25
 
 ### Other

--- a/src/yopo/Cargo.toml
+++ b/src/yopo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yopo"
-version = "1.2.1"
+version = "1.3.0"
 edition = "2024"
 description = "YOPO (You Only Prompt Once) - A simple ACP client for one-shot prompts"
 license = "MIT OR Apache-2.0"
@@ -14,8 +14,8 @@ name = "yopo"
 path = "src/main.rs"
 
 [dependencies]
-sacp = { version = "1.1.1", path = "../sacp" }
-sacp-tokio = { version = "2.0.1", path = "../sacp-tokio" }
+sacp = { version = "2.0.0", path = "../sacp" }
+sacp-tokio = { version = "2.1.0", path = "../sacp-tokio" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tracing.workspace = true
 tracing-subscriber.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `sacp`: 1.1.1 -> 2.0.0 (⚠ API breaking changes)
* `sacp-proxy`: 2.0.2 -> 3.0.0 (⚠ API breaking changes)
* `sacp-tokio`: 2.0.1 -> 2.1.0 (✓ API compatible changes)
* `yopo`: 1.2.1 -> 1.3.0 (✓ API compatible changes)
* `sacp-test`: 1.0.0
* `sacp-trace-viewer`: 0.1.0
* `sacp-conductor`: 3.0.0 -> 4.0.0 (⚠ API breaking changes)
* `elizacp`: 3.0.1 -> 3.0.2
* `sacp-rmcp`: 0.8.4 -> 0.8.5
* `sacp-tee`: 0.1.2 -> 0.1.3

### ⚠ `sacp` breaking changes

```text
--- failure trait_added_supertrait: non-sealed trait added new supertraits ---

Description:
A non-sealed trait added one or more supertraits, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#generic-bounds-tighten
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/trait_added_supertrait.ron

Failed in:
  trait sacp::JrMessage gained Clone in file /tmp/.tmpW1GSqs/symposium-acp/src/sacp/src/jsonrpc.rs:1488

--- failure trait_method_added: pub trait method added ---

Description:
A non-sealed public trait added a new method without a default implementation, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-item-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/trait_method_added.ron

Failed in:
  trait method sacp::JrMessage::to_untyped_message in file /tmp/.tmpW1GSqs/symposium-acp/src/sacp/src/jsonrpc.rs:1490

--- failure trait_method_missing: pub trait method removed or renamed ---

Description:
A trait method is no longer callable, and may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#major-any-change-to-trait-item-signatures
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/trait_method_missing.ron

Failed in:
  method into_untyped_message of trait JrMessage, previously in file /tmp/.tmp8pYIn9/sacp/src/jsonrpc.rs:1481
```

### ⚠ `sacp-proxy` breaking changes

```text
--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/inherent_method_missing.ron

Failed in:
  McpContext::session_id, previously in file /tmp/.tmp8pYIn9/sacp-proxy/src/mcp_server_registry.rs:505

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field session_id of struct McpConnectRequest, previously in file /tmp/.tmp8pYIn9/sacp-proxy/src/mcp_over_acp.rs:17
```

### ⚠ `sacp-conductor` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field ConductorArgs.trace in /tmp/.tmpW1GSqs/symposium-acp/src/sacp-conductor/src/lib.rs:147
  field ConductorArgs.serve in /tmp/.tmpW1GSqs/symposium-acp/src/sacp-conductor/src/lib.rs:152

--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/enum_missing.ron

Failed in:
  enum sacp_conductor::conductor::ConductorMessage, previously in file /tmp/.tmp8pYIn9/sacp-conductor/src/conductor.rs:1104
  enum sacp_conductor::conductor::SourceComponentIndex, previously in file /tmp/.tmp8pYIn9/sacp-conductor/src/conductor.rs:987

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/module_missing.ron

Failed in:
  mod sacp_conductor::conductor, previously in file /tmp/.tmp8pYIn9/sacp-conductor/src/conductor.rs:1

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/struct_missing.ron

Failed in:
  struct sacp_conductor::conductor::ConductorMessageHandler, previously in file /tmp/.tmp8pYIn9/sacp-conductor/src/conductor.rs:224
  struct sacp_conductor::conductor::Conductor, previously in file /tmp/.tmp8pYIn9/sacp-conductor/src/conductor.rs:151

--- failure trait_missing: pub trait removed or renamed ---

Description:
A publicly-visible trait cannot be imported by its prior path. A `pub use` may have been removed, or the trait itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/trait_missing.ron

Failed in:
  trait sacp_conductor::conductor::ComponentList, previously in file /tmp/.tmp8pYIn9/sacp-conductor/src/conductor.rs:1031
  trait sacp_conductor::conductor::JrResponseExt, previously in file /tmp/.tmp8pYIn9/sacp-conductor/src/conductor.rs:1247
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `sacp`

<blockquote>

## [2.0.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-v1.1.1...sacp-v2.0.0) - 2025-11-29

### Added

- *(sacp)* make trace functions generic over MessageAndCx<R, N>
- [**breaking**] change JrMessage trait to take &self and require Clone
- *(conductor)* add trace event logging for sequence diagram visualization
</blockquote>

## `sacp-proxy`

<blockquote>

## [3.0.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-proxy-v2.0.2...sacp-proxy-v3.0.0) - 2025-11-29

### Added

- [**breaking**] change JrMessage trait to take &self and require Clone

### Fixed

- *(conductor)* relax session_id test assertion for early MCP calls
</blockquote>

## `sacp-tokio`

<blockquote>

## [2.1.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-tokio-v2.0.1...sacp-tokio-v2.1.0) - 2025-11-29

### Added

- *(yopo)* accept multiple command arguments with env var support
</blockquote>

## `yopo`

<blockquote>

## [1.3.0](https://github.com/symposium-dev/symposium-acp/compare/yopo-v1.2.1...yopo-v1.3.0) - 2025-11-29

### Added

- *(yopo)* accept multiple command arguments with env var support
</blockquote>

## `sacp-test`

<blockquote>

## [1.0.0](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-test-v1.0.0) - 2025-11-05

### Added

- *(sacp-test)* add arrow proxy for testing

### Other

- update all versions from 1.0.0-alpha to 1.0.0-alpha.1
- release v1.0.0-alpha
- *(conductor)* add integration test with arrow proxy and eliza
- *(conductor)* add integration test with arrow proxy and eliza
- rename sacp-doc-test to sacp-test
</blockquote>

## `sacp-trace-viewer`

<blockquote>

## [0.1.0](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-trace-viewer-v0.1.0) - 2025-11-29

### Added

- *(trace-viewer)* add live trace viewing with --serve flag
- *(trace-viewer)* add content previews for prompts and session updates
- *(trace-viewer)* show delta times on all component timelines
- *(trace-viewer)* add content preview, width slider, and delta times
- *(trace-viewer)* add rainbow colors, request/response linking, and improved UI
- *(conductor)* add trace event system with WriteEvent trait
</blockquote>

## `sacp-conductor`

<blockquote>

## [4.0.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-conductor-v3.0.0...sacp-conductor-v4.0.0) - 2025-11-29

### Added

- *(sacp)* make trace functions generic over MessageAndCx<R, N>
- *(conductor)* add relative timestamps to debug log output
- *(conductor)* add HTTP request UUIDs for tracing
- *(mcp-bridge)* add detailed logging for HTTP message buffering
- *(trace-viewer)* add live trace viewing with --serve flag
- *(conductor)* add trace snapshot test and fix initialize response tracing
- *(conductor)* add trace event system with WriteEvent trait
- *(conductor)* add trace event logging for sequence diagram visualization

### Fixed

- *(conductor)* restore test_session_id_in_mcp_tools to use yopo and acp_url
- *(conductor)* relax session_id test assertion for early MCP calls
- *(conductor)* relax session_id test assertion for early MCP calls
- buffer outgoing messages until HTTP connection is established

### Other

- *(conductor)* improve MCP-over-ACP message tracing
</blockquote>

## `elizacp`

<blockquote>

## [3.0.2](https://github.com/symposium-dev/symposium-acp/compare/elizacp-v3.0.1...elizacp-v3.0.2) - 2025-11-29

### Other

- updated the following local packages: sacp, sacp-tokio
</blockquote>

## `sacp-rmcp`

<blockquote>

## [0.8.5](https://github.com/symposium-dev/symposium-acp/compare/sacp-rmcp-v0.8.4...sacp-rmcp-v0.8.5) - 2025-11-29

### Other

- updated the following local packages: sacp, sacp-proxy
</blockquote>

## `sacp-tee`

<blockquote>

## [0.1.3](https://github.com/symposium-dev/symposium-acp/compare/sacp-tee-v0.1.2...sacp-tee-v0.1.3) - 2025-11-29

### Other

- updated the following local packages: sacp, sacp-proxy, sacp-tokio
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).