### PR TITLE
chore: release

### DIFF
--- a/src/elizacp/CHANGELOG.md
+++ b/src/elizacp/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.0](https://github.com/symposium-dev/symposium-acp/compare/elizacp-v3.0.1...elizacp-v4.0.0) - 2025-12-12
+
+### Added
+
+- [**breaking**] introduce role-based connection API
+
 ## [3.0.1](https://github.com/symposium-dev/symposium-acp/compare/elizacp-v3.0.0...elizacp-v3.0.1) - 2025-11-25
 
 ### Fixed

--- a/src/elizacp/Cargo.toml
+++ b/src/elizacp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elizacp"
-version = "3.0.1"
+version = "4.0.0"
 edition = "2024"
 description = "Classic Eliza chatbot as an ACP agent for testing"
 license = "MIT OR Apache-2.0"
@@ -16,7 +16,7 @@ path = "src/main.rs"
 test = false
 
 [dependencies]
-sacp = { version = "1.1.1", path = "../sacp" }
+sacp = { version = "2.0.0", path = "../sacp" }
 agent-client-protocol-schema.workspace = true
 anyhow.workspace = true
 clap.workspace = true
@@ -31,7 +31,7 @@ tokio-util.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 uuid.workspace = true
-sacp-tokio = { version = "2.0.1", path = "../sacp-tokio" }
+sacp-tokio = { version = "3.0.0", path = "../sacp-tokio" }
 
 [dev-dependencies]
 expect-test.workspace = true

--- a/src/sacp-acp-client/CHANGELOG.md
+++ b/src/sacp-acp-client/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-acp-client-v0.1.0) - 2025-12-12
+
+### Added
+
+- [**breaking**] introduce role-based connection API

--- a/src/sacp-acp-client/Cargo.toml
+++ b/src/sacp-acp-client/Cargo.toml
@@ -5,6 +5,6 @@ edition = "2024"
 
 [dependencies]
 extension-trait = "1.0.2"
-sacp = { version = "1.1.1", path = "../sacp" }
-sacp-conductor = { version = "3.0.0", path = "../sacp-conductor" }
+sacp = { version = "2.0.0", path = "../sacp" }
+sacp-conductor = { version = "4.0.0", path = "../sacp-conductor" }
 serde_json.workspace = true

--- a/src/sacp-conductor/CHANGELOG.md
+++ b/src/sacp-conductor/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-conductor-v3.0.0...sacp-conductor-v4.0.0) - 2025-12-12
+
+### Added
+
+- [**breaking**] introduce role-based connection API
+
 ## [3.0.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-conductor-v2.1.1...sacp-conductor-v3.0.0) - 2025-11-25
 
 ### Added

--- a/src/sacp-conductor/Cargo.toml
+++ b/src/sacp-conductor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-conductor"
-version = "3.0.0"
+version = "4.0.0"
 edition = "2024"
 description = "Conductor for orchestrating SACP proxy chains"
 license = "MIT OR Apache-2.0"
@@ -12,8 +12,8 @@ categories = ["development-tools"]
 test-support = []
 
 [dependencies]
-sacp = { version = "1.1.1", path = "../sacp" }
-sacp-tokio = { version = "2.0.1", path = "../sacp-tokio" }
+sacp = { version = "2.0.0", path = "../sacp" }
+sacp-tokio = { version = "3.0.0", path = "../sacp-tokio" }
 sacp-trace-viewer = { version = "0.1.0", path = "../sacp-trace-viewer" }
 agent-client-protocol-schema.workspace = true
 anyhow.workspace = true

--- a/src/sacp-derive/CHANGELOG.md
+++ b/src/sacp-derive/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [2.0.0](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-derive-v2.0.0) - 2025-12-12
+
+### Added
+
+- *(sacp-derive)* add derive macros for JrRequest, JrNotification, JrResponsePayload
+
+### Other
+
+- use derive macros for proxy_protocol types

--- a/src/sacp-rmcp/CHANGELOG.md
+++ b/src/sacp-rmcp/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-rmcp-v0.8.4...sacp-rmcp-v0.9.0) - 2025-12-12
+
+### Added
+
+- [**breaking**] introduce role-based connection API
+
 ## [0.8.4](https://github.com/symposium-dev/symposium-acp/compare/sacp-rmcp-v0.8.3...sacp-rmcp-v0.8.4) - 2025-11-25
 
 ### Other

--- a/src/sacp-rmcp/Cargo.toml
+++ b/src/sacp-rmcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-rmcp"
-version = "0.8.4"
+version = "0.9.0"
 edition = "2024"
 description = "rmcp integration for SACP proxy components"
 license = "MIT OR Apache-2.0"
@@ -9,7 +9,7 @@ keywords = ["acp", "agent", "proxy", "mcp", "rmcp"]
 categories = ["development-tools"]
 
 [dependencies]
-sacp = { version = "1.1.1", path = "../sacp" }
+sacp = { version = "2.0.0", path = "../sacp" }
 rmcp.workspace = true
 futures.workspace = true
 tokio.workspace = true

--- a/src/sacp-tee/CHANGELOG.md
+++ b/src/sacp-tee/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-tee-v0.1.2...sacp-tee-v0.2.0) - 2025-12-12
+
+### Added
+
+- [**breaking**] introduce role-based connection API
+
 ## [0.1.2](https://github.com/symposium-dev/symposium-acp/compare/sacp-tee-v0.1.1...sacp-tee-v0.1.2) - 2025-11-22
 
 ### Added

--- a/src/sacp-tee/Cargo.toml
+++ b/src/sacp-tee/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-tee"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2024"
 description = "A debugging proxy that logs all ACP traffic to a file"
 license = "MIT OR Apache-2.0"
@@ -12,8 +12,8 @@ categories = ["development-tools", "development-tools::debugging"]
 anyhow.workspace = true
 chrono.workspace = true
 clap = { workspace = true, features = ["derive"] }
-sacp = { version = "1.1", path = "../sacp" }
-sacp-tokio = { version = "2.0", path = "../sacp-tokio" }
+sacp = { version = "2.0", path = "../sacp" }
+sacp-tokio = { version = "3.0", path = "../sacp-tokio" }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 tokio = { workspace = true, features = ["full"] }

--- a/src/sacp-tokio/CHANGELOG.md
+++ b/src/sacp-tokio/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-tokio-v2.0.1...sacp-tokio-v3.0.0) - 2025-12-12
+
+### Added
+
+- [**breaking**] introduce role-based connection API
+
 ## [2.0.1](https://github.com/symposium-dev/symposium-acp/compare/sacp-tokio-v2.0.0...sacp-tokio-v2.0.1) - 2025-11-25
 
 ### Other

--- a/src/sacp-tokio/Cargo.toml
+++ b/src/sacp-tokio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-tokio"
-version = "2.0.1"
+version = "3.0.0"
 edition = "2024"
 description = "Tokio-based utilities for SACP (Symposium's extensions to ACP)"
 license = "MIT OR Apache-2.0"
@@ -9,7 +9,7 @@ keywords = ["acp", "agent", "protocol", "ai", "tokio"]
 categories = ["development-tools"]
 
 [dependencies]
-sacp = { version = "1.1.1", path = "../sacp" }
+sacp = { version = "2.0.0", path = "../sacp" }
 futures.workspace = true
 
 serde.workspace = true

--- a/src/sacp/CHANGELOG.md
+++ b/src/sacp/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-v1.1.1...sacp-v2.0.0) - 2025-12-12
+
+### Added
+
+- *(sacp-derive)* add derive macros for JrRequest, JrNotification, JrResponsePayload
+- *(deps)* [**breaking**] upgrade rmcp from 0.8 to 0.9
+- [**breaking**] introduce role-based connection API
+
+### Other
+
+- add derive macro examples to JrRequest, JrNotification, JrResponsePayload traits
+- use derive macros for proxy_protocol types
+- fix broken GitHub org references in src/**/*.rs files
+- fix broken GitHub org references in src/**/*.rs files
+
 ## [1.1.1](https://github.com/symposium-dev/symposium-acp/compare/sacp-v1.1.0...sacp-v1.1.1) - 2025-11-25
 
 ### Other

--- a/src/sacp/Cargo.toml
+++ b/src/sacp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp"
-version = "1.1.1"
+version = "2.0.0"
 edition = "2024"
 description = "Core protocol types and traits for SACP (Symposium's extensions to ACP)"
 license = "MIT OR Apache-2.0"

--- a/src/yopo/CHANGELOG.md
+++ b/src/yopo/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0](https://github.com/symposium-dev/symposium-acp/compare/yopo-v1.2.1...yopo-v2.0.0) - 2025-12-12
+
+### Added
+
+- [**breaking**] introduce role-based connection API
+
 ## [1.2.1](https://github.com/symposium-dev/symposium-acp/compare/yopo-v1.2.0...yopo-v1.2.1) - 2025-11-25
 
 ### Other

--- a/src/yopo/Cargo.toml
+++ b/src/yopo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yopo"
-version = "1.2.1"
+version = "2.0.0"
 edition = "2024"
 description = "YOPO (You Only Prompt Once) - A simple ACP client for one-shot prompts"
 license = "MIT OR Apache-2.0"
@@ -14,8 +14,8 @@ name = "yopo"
 path = "src/main.rs"
 
 [dependencies]
-sacp = { version = "1.1.1", path = "../sacp" }
-sacp-tokio = { version = "2.0.1", path = "../sacp-tokio" }
+sacp = { version = "2.0.0", path = "../sacp" }
+sacp-tokio = { version = "3.0.0", path = "../sacp-tokio" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tracing.workspace = true
 tracing-subscriber.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `sacp-derive`: 2.0.0
* `sacp`: 1.1.1 -> 2.0.0 (✓ API compatible changes)
* `sacp-tokio`: 2.0.1 -> 3.0.0 (✓ API compatible changes)
* `sacp-conductor`: 3.0.0 -> 4.0.0 (✓ API compatible changes)
* `yopo`: 1.2.1 -> 2.0.0 (✓ API compatible changes)
* `sacp-test`: 1.0.0
* `elizacp`: 3.0.1 -> 4.0.0 (✓ API compatible changes)
* `sacp-rmcp`: 0.8.4 -> 0.9.0 (✓ API compatible changes)
* `sacp-tee`: 0.1.2 -> 0.2.0 (✓ API compatible changes)
* `sacp-acp-client`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `sacp-derive`

<blockquote>

## [2.0.0](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-derive-v2.0.0) - 2025-12-12

### Added

- *(sacp-derive)* add derive macros for JrRequest, JrNotification, JrResponsePayload

### Other

- use derive macros for proxy_protocol types
</blockquote>

## `sacp`

<blockquote>

## [2.0.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-v1.1.1...sacp-v2.0.0) - 2025-12-12

### Added

- *(sacp-derive)* add derive macros for JrRequest, JrNotification, JrResponsePayload
- *(deps)* [**breaking**] upgrade rmcp from 0.8 to 0.9
- [**breaking**] introduce role-based connection API

### Other

- add derive macro examples to JrRequest, JrNotification, JrResponsePayload traits
- use derive macros for proxy_protocol types
- fix broken GitHub org references in src/**/*.rs files
- fix broken GitHub org references in src/**/*.rs files
</blockquote>

## `sacp-tokio`

<blockquote>

## [3.0.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-tokio-v2.0.1...sacp-tokio-v3.0.0) - 2025-12-12

### Added

- [**breaking**] introduce role-based connection API
</blockquote>

## `sacp-conductor`

<blockquote>

## [4.0.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-conductor-v3.0.0...sacp-conductor-v4.0.0) - 2025-12-12

### Added

- [**breaking**] introduce role-based connection API
</blockquote>

## `yopo`

<blockquote>

## [2.0.0](https://github.com/symposium-dev/symposium-acp/compare/yopo-v1.2.1...yopo-v2.0.0) - 2025-12-12

### Added

- [**breaking**] introduce role-based connection API
</blockquote>

## `sacp-test`

<blockquote>

## [1.0.0](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-test-v1.0.0) - 2025-11-05

### Added

- *(sacp-test)* add arrow proxy for testing

### Other

- update all versions from 1.0.0-alpha to 1.0.0-alpha.1
- release v1.0.0-alpha
- *(conductor)* add integration test with arrow proxy and eliza
- *(conductor)* add integration test with arrow proxy and eliza
- rename sacp-doc-test to sacp-test
</blockquote>

## `elizacp`

<blockquote>

## [4.0.0](https://github.com/symposium-dev/symposium-acp/compare/elizacp-v3.0.1...elizacp-v4.0.0) - 2025-12-12

### Added

- [**breaking**] introduce role-based connection API
</blockquote>

## `sacp-rmcp`

<blockquote>

## [0.9.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-rmcp-v0.8.4...sacp-rmcp-v0.9.0) - 2025-12-12

### Added

- [**breaking**] introduce role-based connection API
</blockquote>

## `sacp-tee`

<blockquote>

## [0.2.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-tee-v0.1.2...sacp-tee-v0.2.0) - 2025-12-12

### Added

- [**breaking**] introduce role-based connection API
</blockquote>

## `sacp-acp-client`

<blockquote>

## [0.1.0](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-acp-client-v0.1.0) - 2025-12-12

### Added

- [**breaking**] introduce role-based connection API
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).