### PR TITLE
chore: release

### DIFF
--- a/src/elizacp/Cargo.toml
+++ b/src/elizacp/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/main.rs"
 test = false
 
 [dependencies]
-sacp = { version = "2.0.0", path = "../sacp" }
+sacp = { version = "3.0.0", path = "../sacp" }
 agent-client-protocol-schema.workspace = true
 anyhow.workspace = true
 clap.workspace = true

--- a/src/sacp-acp-client/Cargo.toml
+++ b/src/sacp-acp-client/Cargo.toml
@@ -5,6 +5,6 @@ edition = "2024"
 
 [dependencies]
 extension-trait = "1.0.2"
-sacp = { version = "2.0.0", path = "../sacp" }
-sacp-conductor = { version = "4.0.0", path = "../sacp-conductor" }
+sacp = { version = "3.0.0", path = "../sacp" }
+sacp-conductor = { version = "5.0.0", path = "../sacp-conductor" }
 serde_json.workspace = true

--- a/src/sacp-conductor/CHANGELOG.md
+++ b/src/sacp-conductor/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.0.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-conductor-v4.0.0...sacp-conductor-v5.0.0) - 2025-12-12
+
+### Added
+
+- [**breaking**] introduce role-based connection API
+
+### Other
+
+- release
+
 ## [4.0.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-conductor-v3.0.0...sacp-conductor-v4.0.0) - 2025-12-12
 
 ### Added

--- a/src/sacp-conductor/Cargo.toml
+++ b/src/sacp-conductor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-conductor"
-version = "4.0.0"
+version = "5.0.0"
 edition = "2024"
 description = "Conductor for orchestrating SACP proxy chains"
 license = "MIT OR Apache-2.0"
@@ -12,7 +12,7 @@ categories = ["development-tools"]
 test-support = []
 
 [dependencies]
-sacp = { version = "2.0.0", path = "../sacp" }
+sacp = { version = "3.0.0", path = "../sacp" }
 sacp-tokio = { version = "3.0.0", path = "../sacp-tokio" }
 sacp-trace-viewer = { version = "0.1.0", path = "../sacp-trace-viewer" }
 agent-client-protocol-schema.workspace = true

--- a/src/sacp-rmcp/Cargo.toml
+++ b/src/sacp-rmcp/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["acp", "agent", "proxy", "mcp", "rmcp"]
 categories = ["development-tools"]
 
 [dependencies]
-sacp = { version = "2.0.0", path = "../sacp" }
+sacp = { version = "3.0.0", path = "../sacp" }
 rmcp.workspace = true
 futures.workspace = true
 tokio.workspace = true

--- a/src/sacp-tee/Cargo.toml
+++ b/src/sacp-tee/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["development-tools", "development-tools::debugging"]
 anyhow.workspace = true
 chrono.workspace = true
 clap = { workspace = true, features = ["derive"] }
-sacp = { version = "2.0", path = "../sacp" }
+sacp = { version = "3.0", path = "../sacp" }
 sacp-tokio = { version = "3.0", path = "../sacp-tokio" }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true

--- a/src/sacp-tokio/Cargo.toml
+++ b/src/sacp-tokio/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["acp", "agent", "protocol", "ai", "tokio"]
 categories = ["development-tools"]
 
 [dependencies]
-sacp = { version = "2.0.0", path = "../sacp" }
+sacp = { version = "3.0.0", path = "../sacp" }
 futures.workspace = true
 
 serde.workspace = true

--- a/src/sacp/CHANGELOG.md
+++ b/src/sacp/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-v2.0.0...sacp-v3.0.0) - 2025-12-12
+
+### Added
+
+- *(sacp-derive)* add derive macros for JrRequest, JrNotification, JrResponsePayload
+- *(deps)* [**breaking**] upgrade rmcp from 0.8 to 0.9
+- [**breaking**] introduce role-based connection API
+
+### Other
+
+- release
+- add derive macro examples to JrRequest, JrNotification, JrResponsePayload traits
+- use derive macros for proxy_protocol types
+- fix broken GitHub org references in src/**/*.rs files
+- fix broken GitHub org references in src/**/*.rs files
+
 ## [2.0.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-v1.1.1...sacp-v2.0.0) - 2025-12-12
 
 ### Added

--- a/src/sacp/Cargo.toml
+++ b/src/sacp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp"
-version = "2.0.0"
+version = "3.0.0"
 edition = "2024"
 description = "Core protocol types and traits for SACP (Symposium's extensions to ACP)"
 license = "MIT OR Apache-2.0"

--- a/src/yopo/Cargo.toml
+++ b/src/yopo/Cargo.toml
@@ -14,7 +14,7 @@ name = "yopo"
 path = "src/main.rs"
 
 [dependencies]
-sacp = { version = "2.0.0", path = "../sacp" }
+sacp = { version = "3.0.0", path = "../sacp" }
 sacp-tokio = { version = "3.0.0", path = "../sacp-tokio" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tracing.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `sacp-derive`: 2.0.0
* `sacp`: 2.0.0 -> 3.0.0 (⚠ API breaking changes)
* `sacp-conductor`: 4.0.0 -> 5.0.0 (✓ API compatible changes)
* `sacp-test`: 1.0.0
* `sacp-acp-client`: 0.1.0

### ⚠ `sacp` breaking changes

```text
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/enum_missing.ron

Failed in:
  enum sacp::MessageAndCx, previously in file /tmp/.tmpmm7mLj/sacp/src/jsonrpc.rs:1551

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/inherent_method_missing.ron

Failed in:
  JrConnectionCx::send_proxied_message, previously in file /tmp/.tmpmm7mLj/sacp/src/jsonrpc.rs:1154
  JrRequestCx::connection_cx, previously in file /tmp/.tmpmm7mLj/sacp/src/jsonrpc.rs:1453

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/method_parameter_count_changed.ron

Failed in:
  sacp::handler::RequestHandler::new now takes 3 parameters instead of 1, in /tmp/.tmpHHdknz/symposium-acp/src/sacp/src/jsonrpc/handlers.rs:51
  sacp::handler::MessageHandler::new now takes 3 parameters instead of 1, in /tmp/.tmpHHdknz/symposium-acp/src/sacp/src/jsonrpc/handlers.rs:263
  sacp::handler::NotificationHandler::new now takes 3 parameters instead of 1, in /tmp/.tmpHHdknz/symposium-acp/src/sacp/src/jsonrpc/handlers.rs:157

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/struct_missing.ron

Failed in:
  struct sacp::Proxy, previously in file /tmp/.tmpmm7mLj/sacp/src/capabilities.rs:40
  struct sacp::JrHandlerChain, previously in file /tmp/.tmpmm7mLj/sacp/src/jsonrpc.rs:354

--- failure trait_associated_type_added: non-sealed public trait added associated type without default value ---

Description:
A non-sealed trait has gained an associated type without a default value, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-item-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/trait_associated_type_added.ron

Failed in:
  trait associated type sacp::JrMessageHandler::Role in file /tmp/.tmpHHdknz/symposium-acp/src/sacp/src/jsonrpc.rs:41

--- failure trait_method_added: pub trait method added ---

Description:
A non-sealed public trait added a new method without a default implementation, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-item-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/trait_method_added.ron

Failed in:
  trait method sacp::JrMessage::parse_message in file /tmp/.tmpHHdknz/symposium-acp/src/sacp/src/jsonrpc.rs:1820

--- failure trait_method_missing: pub trait method removed or renamed ---

Description:
A trait method is no longer callable, and may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#major-any-change-to-trait-item-signatures
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/trait_method_missing.ron

Failed in:
  method parse_request of trait JrMessage, previously in file /tmp/.tmpmm7mLj/sacp/src/jsonrpc.rs:1501
  method parse_notification of trait JrMessage, previously in file /tmp/.tmpmm7mLj/sacp/src/jsonrpc.rs:1510

--- failure trait_method_parameter_count_changed: pub trait method parameter count changed ---

Description:
A trait method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#major-any-change-to-trait-item-signatures
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/trait_method_parameter_count_changed.ron

Failed in:
  JrMessageHandler::handle_message now takes 3 instead of 2 parameters, in file /tmp/.tmpHHdknz/symposium-acp/src/sacp/src/jsonrpc.rs:61

--- failure trait_requires_more_generic_type_params: trait now requires more generic type parameters ---

Description:
A trait now requires more generic type parameters than it used to. Uses of this trait that supplied the previously-required number of generic types will be broken. To fix this, consider supplying default values for newly-added generic types.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-parameter-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/trait_requires_more_generic_type_params.ron

Failed in:
  trait JrConnectionCx (0 -> 1 required generic types) in /tmp/.tmpHHdknz/symposium-acp/src/sacp/src/jsonrpc.rs:1249
  trait TypeNotification (0 -> 1 required generic types) in /tmp/.tmpHHdknz/symposium-acp/src/sacp/src/util/typed.rs:382
  trait NullHandler (0 -> 1 required generic types) in /tmp/.tmpHHdknz/symposium-acp/src/sacp/src/jsonrpc/handlers.rs:10

--- failure type_requires_more_generic_type_params: type now requires more generic type parameters ---

Description:
A type now requires more generic type parameters than it used to. Uses of this type that supplied the previously-required number of generic types will be broken. To fix this, consider supplying default values for newly-added generic types.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-parameter-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/type_requires_more_generic_type_params.ron

Failed in:
  Struct JrConnectionCx (0 -> 1 required generic types) in /tmp/.tmpHHdknz/symposium-acp/src/sacp/src/jsonrpc.rs:1249
  Struct TypeNotification (0 -> 1 required generic types) in /tmp/.tmpHHdknz/symposium-acp/src/sacp/src/util/typed.rs:382
  Struct NullHandler (0 -> 1 required generic types) in /tmp/.tmpHHdknz/symposium-acp/src/sacp/src/jsonrpc/handlers.rs:10
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `sacp-derive`

<blockquote>

## [2.0.0](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-derive-v2.0.0) - 2025-12-12

### Added

- *(sacp-derive)* add derive macros for JrRequest, JrNotification, JrResponsePayload

### Other

- use derive macros for proxy_protocol types
</blockquote>

## `sacp`

<blockquote>

## [3.0.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-v2.0.0...sacp-v3.0.0) - 2025-12-12

### Added

- *(sacp-derive)* add derive macros for JrRequest, JrNotification, JrResponsePayload
- *(deps)* [**breaking**] upgrade rmcp from 0.8 to 0.9
- [**breaking**] introduce role-based connection API

### Other

- release
- add derive macro examples to JrRequest, JrNotification, JrResponsePayload traits
- use derive macros for proxy_protocol types
- fix broken GitHub org references in src/**/*.rs files
- fix broken GitHub org references in src/**/*.rs files
</blockquote>

## `sacp-conductor`

<blockquote>

## [5.0.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-conductor-v4.0.0...sacp-conductor-v5.0.0) - 2025-12-12

### Added

- [**breaking**] introduce role-based connection API

### Other

- release
</blockquote>

## `sacp-test`

<blockquote>

## [1.0.0](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-test-v1.0.0) - 2025-11-05

### Added

- *(sacp-test)* add arrow proxy for testing

### Other

- update all versions from 1.0.0-alpha to 1.0.0-alpha.1
- release v1.0.0-alpha
- *(conductor)* add integration test with arrow proxy and eliza
- *(conductor)* add integration test with arrow proxy and eliza
- rename sacp-doc-test to sacp-test
</blockquote>

## `sacp-acp-client`

<blockquote>

## [0.1.0](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-acp-client-v0.1.0) - 2025-12-12

### Added

- [**breaking**] introduce role-based connection API
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).