### PR TITLE
chore: release

### DIFF
--- a/src/sacp-derive/CHANGELOG.md
+++ b/src/sacp-derive/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.1](https://github.com/symposium-dev/symposium-acp/compare/sacp-derive-v2.0.0...sacp-derive-v2.0.1) - 2025-12-12
+
+### Other
+
+- release
+
 ## [2.0.0](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-derive-v2.0.0) - 2025-12-12
 
 ### Added

--- a/src/sacp-derive/Cargo.toml
+++ b/src/sacp-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-derive"
-version = "2.0.0"
+version = "2.0.1"
 edition = "2021"
 description = "Derive macros for SACP JSON-RPC traits"
 license = "MIT OR Apache-2.0"

--- a/src/sacp/Cargo.toml
+++ b/src/sacp/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["development-tools"]
 
 [dependencies]
 agent-client-protocol-schema.workspace = true
-sacp-derive = { version = "2.0.0", path = "../sacp-derive" }
+sacp-derive = { version = "2.0.1", path = "../sacp-derive" }
 anyhow.workspace = true
 boxfnonce.workspace = true
 futures.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `sacp-derive`: 2.0.0 -> 2.0.1
* `sacp-test`: 1.0.0
* `sacp-acp-client`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `sacp-derive`

<blockquote>

## [2.0.1](https://github.com/symposium-dev/symposium-acp/compare/sacp-derive-v2.0.0...sacp-derive-v2.0.1) - 2025-12-12

### Other

- release
</blockquote>

## `sacp-test`

<blockquote>

## [1.0.0](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-test-v1.0.0) - 2025-11-05

### Added

- *(sacp-test)* add arrow proxy for testing

### Other

- update all versions from 1.0.0-alpha to 1.0.0-alpha.1
- release v1.0.0-alpha
- *(conductor)* add integration test with arrow proxy and eliza
- *(conductor)* add integration test with arrow proxy and eliza
- rename sacp-doc-test to sacp-test
</blockquote>

## `sacp-acp-client`

<blockquote>

## [0.1.0](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-acp-client-v0.1.0) - 2025-12-12

### Added

- [**breaking**] introduce role-based connection API
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).