### PR TITLE
ci(mdbook): fix workflow for forks and update mdbook version

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -28,8 +28,10 @@ jobs:
   # Build job
   build:
     runs-on: ubuntu-latest
+    # Only run on the main repository, not on forks
+    if: github.repository == 'symposium-dev/symposium-acp'
     env:
-      MDBOOK_VERSION: 0.4.36
+      MDBOOK_VERSION: 0.5.1
     steps:
       - uses: actions/checkout@v4
       - name: Install mdBook
@@ -55,6 +57,8 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
+    # Only run on the main repository, not on forks
+    if: github.repository == 'symposium-dev/symposium-acp'
     steps:
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
- Skip build/deploy jobs on forks where GitHub Pages isn't configured
- Update mdbook from 0.4.36 to 0.5.1 for mermaid preprocessor compatibility