### PR TITLE
chore: release

### DIFF
--- a/src/elizacp/CHANGELOG.md
+++ b/src/elizacp/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.1](https://github.com/symposium-dev/symposium-acp/compare/elizacp-v4.0.0...elizacp-v4.0.1) - 2025-12-15
+
+### Other
+
+- updated the following local packages: sacp, sacp-tokio
+
 ## [4.0.0](https://github.com/symposium-dev/symposium-acp/compare/elizacp-v3.0.1...elizacp-v4.0.0) - 2025-12-12
 
 ### Added

--- a/src/elizacp/Cargo.toml
+++ b/src/elizacp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elizacp"
-version = "4.0.0"
+version = "4.0.1"
 edition = "2024"
 description = "Classic Eliza chatbot as an ACP agent for testing"
 license = "MIT OR Apache-2.0"
@@ -16,7 +16,7 @@ path = "src/main.rs"
 test = false
 
 [dependencies]
-sacp = { version = "3.0.0", path = "../sacp" }
+sacp = { version = "4.0.0", path = "../sacp" }
 agent-client-protocol-schema.workspace = true
 anyhow.workspace = true
 clap.workspace = true
@@ -31,7 +31,7 @@ tokio-util.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 uuid.workspace = true
-sacp-tokio = { version = "3.0.0", path = "../sacp-tokio" }
+sacp-tokio = { version = "3.0.1", path = "../sacp-tokio" }
 
 [dev-dependencies]
 expect-test.workspace = true

--- a/src/sacp-conductor/CHANGELOG.md
+++ b/src/sacp-conductor/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.0.1](https://github.com/symposium-dev/symposium-acp/compare/sacp-conductor-v5.0.0...sacp-conductor-v5.0.1) - 2025-12-15
+
+### Other
+
+- *(sacp)* rename MatchMessage to MatchMessageFrom
+- new session redirection support
+
 ## [5.0.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-conductor-v4.0.0...sacp-conductor-v5.0.0) - 2025-12-12
 
 ### Added

--- a/src/sacp-conductor/Cargo.toml
+++ b/src/sacp-conductor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-conductor"
-version = "5.0.0"
+version = "5.0.1"
 edition = "2024"
 description = "Conductor for orchestrating SACP proxy chains"
 license = "MIT OR Apache-2.0"
@@ -12,8 +12,8 @@ categories = ["development-tools"]
 test-support = []
 
 [dependencies]
-sacp = { version = "3.0.0", path = "../sacp" }
-sacp-tokio = { version = "3.0.0", path = "../sacp-tokio" }
+sacp = { version = "4.0.0", path = "../sacp" }
+sacp-tokio = { version = "3.0.1", path = "../sacp-tokio" }
 sacp-trace-viewer = { version = "0.1.0", path = "../sacp-trace-viewer" }
 agent-client-protocol-schema.workspace = true
 anyhow.workspace = true

--- a/src/sacp-rmcp/CHANGELOG.md
+++ b/src/sacp-rmcp/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-rmcp-v0.9.0...sacp-rmcp-v0.10.0) - 2025-12-15
+
+### Other
+
+- new session redirection support
+
 ## [0.9.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-rmcp-v0.8.4...sacp-rmcp-v0.9.0) - 2025-12-12
 
 ### Added

--- a/src/sacp-rmcp/Cargo.toml
+++ b/src/sacp-rmcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-rmcp"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 description = "rmcp integration for SACP proxy components"
 license = "MIT OR Apache-2.0"
@@ -9,7 +9,7 @@ keywords = ["acp", "agent", "proxy", "mcp", "rmcp"]
 categories = ["development-tools"]
 
 [dependencies]
-sacp = { version = "3.0.0", path = "../sacp" }
+sacp = { version = "4.0.0", path = "../sacp" }
 rmcp.workspace = true
 futures.workspace = true
 tokio.workspace = true

--- a/src/sacp-tee/CHANGELOG.md
+++ b/src/sacp-tee/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/symposium-dev/symposium-acp/compare/sacp-tee-v0.2.0...sacp-tee-v0.2.1) - 2025-12-15
+
+### Other
+
+- new session redirection support
+
 ## [0.2.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-tee-v0.1.2...sacp-tee-v0.2.0) - 2025-12-12
 
 ### Added

--- a/src/sacp-tee/Cargo.toml
+++ b/src/sacp-tee/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-tee"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 description = "A debugging proxy that logs all ACP traffic to a file"
 license = "MIT OR Apache-2.0"
@@ -12,7 +12,7 @@ categories = ["development-tools", "development-tools::debugging"]
 anyhow.workspace = true
 chrono.workspace = true
 clap = { workspace = true, features = ["derive"] }
-sacp = { version = "3.0", path = "../sacp" }
+sacp = { version = "4.0", path = "../sacp" }
 sacp-tokio = { version = "3.0", path = "../sacp-tokio" }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true

--- a/src/sacp-test/Cargo.toml
+++ b/src/sacp-test/Cargo.toml
@@ -10,8 +10,8 @@ name = "mcp-echo-server"
 path = "src/bin/mcp_echo_server.rs"
 
 [dependencies]
-sacp = { version = "3.0.0", path = "../sacp" }
-yopo = { version = "2.0.0", path = "../yopo" }
+sacp = { version = "4.0.0", path = "../sacp" }
+yopo = { version = "2.0.1", path = "../yopo" }
 rmcp = { workspace = true, features = ["server"] }
 schemars.workspace = true
 

--- a/src/sacp-tokio/CHANGELOG.md
+++ b/src/sacp-tokio/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.1](https://github.com/symposium-dev/symposium-acp/compare/sacp-tokio-v3.0.0...sacp-tokio-v3.0.1) - 2025-12-15
+
+### Fixed
+
+- *(sacp-tokio)* report child process errors with stderr in AcpAgent
+
 ## [3.0.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-tokio-v2.0.1...sacp-tokio-v3.0.0) - 2025-12-12
 
 ### Added

--- a/src/sacp-tokio/Cargo.toml
+++ b/src/sacp-tokio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-tokio"
-version = "3.0.0"
+version = "3.0.1"
 edition = "2024"
 description = "Tokio-based utilities for SACP (Symposium's extensions to ACP)"
 license = "MIT OR Apache-2.0"
@@ -9,7 +9,7 @@ keywords = ["acp", "agent", "protocol", "ai", "tokio"]
 categories = ["development-tools"]
 
 [dependencies]
-sacp = { version = "3.0.0", path = "../sacp" }
+sacp = { version = "4.0.0", path = "../sacp" }
 futures.workspace = true
 
 serde.workspace = true

--- a/src/sacp/CHANGELOG.md
+++ b/src/sacp/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-v3.0.0...sacp-v4.0.0) - 2025-12-15
+
+### Fixed
+
+- tests now pass
+- *(sacp)* use correct camelCase field name for sessionId lookup
+- *(sacp)* use blocking next() instead of try_next() in session read_update
+
+### Other
+
+- Merge pull request #77 from nikomatsakis/main
+- *(sacp)* add guidance on when to use MatchMessage vs MatchMessageFrom
+- *(sacp)* extract role-agnostic MatchMessage from MatchMessageFrom
+- *(sacp)* rename MatchMessage to MatchMessageFrom
+- process user-handlers first, dynamic later
+- new session redirection support
+
 ## [3.0.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-v2.0.0...sacp-v3.0.0) - 2025-12-12
 
 ### Added

--- a/src/sacp/Cargo.toml
+++ b/src/sacp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp"
-version = "3.0.0"
+version = "4.0.0"
 edition = "2024"
 description = "Core protocol types and traits for SACP (Symposium's extensions to ACP)"
 license = "MIT OR Apache-2.0"

--- a/src/yopo/CHANGELOG.md
+++ b/src/yopo/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.1](https://github.com/symposium-dev/symposium-acp/compare/yopo-v2.0.0...yopo-v2.0.1) - 2025-12-15
+
+### Fixed
+
+- *(yopo)* remove unused MatchMessageFrom import
+
+### Other
+
+- *(sacp)* add guidance on when to use MatchMessage vs MatchMessageFrom
+- *(sacp)* rename MatchMessage to MatchMessageFrom
+- new session redirection support
+
 ## [2.0.0](https://github.com/symposium-dev/symposium-acp/compare/yopo-v1.2.1...yopo-v2.0.0) - 2025-12-12
 
 ### Added

--- a/src/yopo/Cargo.toml
+++ b/src/yopo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yopo"
-version = "2.0.0"
+version = "2.0.1"
 edition = "2024"
 description = "YOPO (You Only Prompt Once) - A simple ACP client for one-shot prompts"
 license = "MIT OR Apache-2.0"
@@ -14,8 +14,8 @@ name = "yopo"
 path = "src/main.rs"
 
 [dependencies]
-sacp = { version = "3.0.0", path = "../sacp" }
-sacp-tokio = { version = "3.0.0", path = "../sacp-tokio" }
+sacp = { version = "4.0.0", path = "../sacp" }
+sacp-tokio = { version = "3.0.1", path = "../sacp-tokio" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tracing.workspace = true
 tracing-subscriber.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `sacp`: 3.0.0 -> 4.0.0 (⚠ API breaking changes)
* `sacp-tokio`: 3.0.0 -> 3.0.1 (✓ API compatible changes)
* `sacp-conductor`: 5.0.0 -> 5.0.1 (✓ API compatible changes)
* `yopo`: 2.0.0 -> 2.0.1 (✓ API compatible changes)
* `sacp-test`: 1.0.0
* `sacp-rmcp`: 0.9.0 -> 0.10.0 (⚠ API breaking changes)
* `sacp-tee`: 0.2.0 -> 0.2.1 (✓ API compatible changes)
* `elizacp`: 4.0.0 -> 4.0.1

### ⚠ `sacp` breaking changes

```text
--- failure auto_trait_impl_removed: auto trait no longer implemented ---

Description:
A public type has stopped implementing one or more auto traits. This can break downstream code that depends on the traits being implemented.
        ref: https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/auto_trait_impl_removed.ron

Failed in:
  type McpServiceRegistry is no longer UnwindSafe, in /tmp/.tmpLdufPX/symposium-acp/src/sacp/src/mcp_server/registry.rs:30
  type McpServiceRegistry is no longer RefUnwindSafe, in /tmp/.tmpLdufPX/symposium-acp/src/sacp/src/mcp_server/registry.rs:30

--- failure enum_tuple_variant_changed_kind: An enum tuple variant changed kind ---

Description:
A public enum's exhaustive tuple variant has changed to a different kind of enum variant, breaking possible instantiations and patterns.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/enum_tuple_variant_changed_kind.ron

Failed in:
  variant Handled::No in /tmp/.tmpLdufPX/symposium-acp/src/sacp/src/jsonrpc.rs:1192

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/inherent_method_missing.ron

Failed in:
  MatchMessage::if_request_from, previously in file /tmp/.tmpJtQSbP/sacp/src/util/typed.rs:144
  MatchMessage::if_notification_from, previously in file /tmp/.tmpJtQSbP/sacp/src/util/typed.rs:264
  McpServiceRegistry::add_mcp_server, previously in file /tmp/.tmpJtQSbP/sacp/src/mcp_server/registry.rs:80
  McpServiceRegistry::add_mcp_server_with_context, previously in file /tmp/.tmpJtQSbP/sacp/src/mcp_server/registry.rs:115

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/method_parameter_count_changed.ron

Failed in:
  sacp::mcp_server::McpServiceRegistry::add_registered_mcp_servers_to now takes 3 parameters instead of 2, in /tmp/.tmpLdufPX/symposium-acp/src/sacp/src/mcp_server/registry.rs:131

--- failure trait_associated_type_added: non-sealed public trait added associated type without default value ---

Description:
A non-sealed trait has gained an associated type without a default value, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-item-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/trait_associated_type_added.ron

Failed in:
  trait associated type sacp::role::JrRole::State in file /tmp/.tmpLdufPX/symposium-acp/src/sacp/src/role.rs:42
  trait associated type sacp::JrRole::State in file /tmp/.tmpLdufPX/symposium-acp/src/sacp/src/role.rs:42

--- failure trait_method_parameter_count_changed: pub trait method parameter count changed ---

Description:
A trait method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#major-any-change-to-trait-item-signatures
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/trait_method_parameter_count_changed.ron

Failed in:
  JrRole::default_message_handler now takes 3 instead of 2 parameters, in file /tmp/.tmpLdufPX/symposium-acp/src/sacp/src/role.rs:46
  JrRole::default_message_handler now takes 3 instead of 2 parameters, in file /tmp/.tmpLdufPX/symposium-acp/src/sacp/src/role.rs:46
```

### ⚠ `sacp-rmcp` breaking changes

```text
--- failure trait_method_missing: pub trait method removed or renamed ---

Description:
A trait method is no longer callable, and may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#major-any-change-to-trait-item-signatures
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/trait_method_missing.ron

Failed in:
  method add_rmcp_server of trait McpServiceRegistryRmcpExt, previously in file /tmp/.tmpJtQSbP/sacp-rmcp/src/lib.rs:38
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `sacp`

<blockquote>

## [4.0.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-v3.0.0...sacp-v4.0.0) - 2025-12-15

### Fixed

- tests now pass
- *(sacp)* use correct camelCase field name for sessionId lookup
- *(sacp)* use blocking next() instead of try_next() in session read_update

### Other

- Merge pull request #77 from nikomatsakis/main
- *(sacp)* add guidance on when to use MatchMessage vs MatchMessageFrom
- *(sacp)* extract role-agnostic MatchMessage from MatchMessageFrom
- *(sacp)* rename MatchMessage to MatchMessageFrom
- process user-handlers first, dynamic later
- new session redirection support
</blockquote>

## `sacp-tokio`

<blockquote>

## [3.0.1](https://github.com/symposium-dev/symposium-acp/compare/sacp-tokio-v3.0.0...sacp-tokio-v3.0.1) - 2025-12-15

### Fixed

- *(sacp-tokio)* report child process errors with stderr in AcpAgent
</blockquote>

## `sacp-conductor`

<blockquote>

## [5.0.1](https://github.com/symposium-dev/symposium-acp/compare/sacp-conductor-v5.0.0...sacp-conductor-v5.0.1) - 2025-12-15

### Other

- *(sacp)* rename MatchMessage to MatchMessageFrom
- new session redirection support
</blockquote>

## `yopo`

<blockquote>

## [2.0.1](https://github.com/symposium-dev/symposium-acp/compare/yopo-v2.0.0...yopo-v2.0.1) - 2025-12-15

### Fixed

- *(yopo)* remove unused MatchMessageFrom import

### Other

- *(sacp)* add guidance on when to use MatchMessage vs MatchMessageFrom
- *(sacp)* rename MatchMessage to MatchMessageFrom
- new session redirection support
</blockquote>

## `sacp-test`

<blockquote>

## [1.0.0](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-test-v1.0.0) - 2025-11-05

### Added

- *(sacp-test)* add arrow proxy for testing

### Other

- update all versions from 1.0.0-alpha to 1.0.0-alpha.1
- release v1.0.0-alpha
- *(conductor)* add integration test with arrow proxy and eliza
- *(conductor)* add integration test with arrow proxy and eliza
- rename sacp-doc-test to sacp-test
</blockquote>

## `sacp-rmcp`

<blockquote>

## [0.10.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-rmcp-v0.9.0...sacp-rmcp-v0.10.0) - 2025-12-15

### Other

- new session redirection support
</blockquote>

## `sacp-tee`

<blockquote>

## [0.2.1](https://github.com/symposium-dev/symposium-acp/compare/sacp-tee-v0.2.0...sacp-tee-v0.2.1) - 2025-12-15

### Other

- new session redirection support
</blockquote>

## `elizacp`

<blockquote>

## [4.0.1](https://github.com/symposium-dev/symposium-acp/compare/elizacp-v4.0.0...elizacp-v4.0.1) - 2025-12-15

### Other

- updated the following local packages: sacp, sacp-tokio
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).