### PR TITLE
chore: release

### DIFF
--- a/src/elizacp/CHANGELOG.md
+++ b/src/elizacp/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [7.0.1](https://github.com/symposium-dev/symposium-acp/compare/elizacp-v7.0.0...elizacp-v7.0.1) - 2025-12-17
+## [8.0.0](https://github.com/symposium-dev/symposium-acp/compare/elizacp-v7.0.0...elizacp-v8.0.0) - 2025-12-17
 
 ### Other
 

--- a/src/elizacp/Cargo.toml
+++ b/src/elizacp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elizacp"
-version = "7.0.1"
+version = "8.0.0"
 edition = "2024"
 description = "Classic Eliza chatbot as an ACP agent for testing"
 license = "MIT OR Apache-2.0"
@@ -16,7 +16,7 @@ path = "src/main.rs"
 test = false
 
 [dependencies]
-sacp = { version = "7.0.1", path = "../sacp" }
+sacp = { version = "8.0.0", path = "../sacp" }
 agent-client-protocol-schema.workspace = true
 anyhow.workspace = true
 clap.workspace = true
@@ -31,7 +31,7 @@ tokio-util.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 uuid.workspace = true
-sacp-tokio = { version = "7.0.1", path = "../sacp-tokio" }
+sacp-tokio = { version = "8.0.0", path = "../sacp-tokio" }
 
 [dev-dependencies]
 expect-test.workspace = true

--- a/src/sacp-conductor/CHANGELOG.md
+++ b/src/sacp-conductor/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [7.0.1](https://github.com/symposium-dev/symposium-acp/compare/sacp-conductor-v7.0.0...sacp-conductor-v7.0.1) - 2025-12-17
+## [8.0.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-conductor-v7.0.0...sacp-conductor-v8.0.0) - 2025-12-17
 
 ### Fixed
 

--- a/src/sacp-conductor/Cargo.toml
+++ b/src/sacp-conductor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-conductor"
-version = "7.0.1"
+version = "8.0.0"
 edition = "2024"
 description = "Conductor for orchestrating SACP proxy chains"
 license = "MIT OR Apache-2.0"
@@ -12,9 +12,9 @@ categories = ["development-tools"]
 test-support = []
 
 [dependencies]
-sacp = { version = "7.0.1", path = "../sacp" }
-sacp-tokio = { version = "7.0.1", path = "../sacp-tokio" }
-sacp-trace-viewer = { version = "7.0.0", path = "../sacp-trace-viewer" }
+sacp = { version = "8.0.0", path = "../sacp" }
+sacp-tokio = { version = "8.0.0", path = "../sacp-tokio" }
+sacp-trace-viewer = { version = "8.0.0", path = "../sacp-trace-viewer" }
 agent-client-protocol-schema.workspace = true
 anyhow.workspace = true
 axum.workspace = true

--- a/src/sacp-derive/Cargo.toml
+++ b/src/sacp-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-derive"
-version = "7.0.0"
+version = "8.0.0"
 edition = "2021"
 description = "Derive macros for SACP JSON-RPC traits"
 license = "MIT OR Apache-2.0"

--- a/src/sacp-rmcp/CHANGELOG.md
+++ b/src/sacp-rmcp/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [7.0.1](https://github.com/symposium-dev/symposium-acp/compare/sacp-rmcp-v7.0.0...sacp-rmcp-v7.0.1) - 2025-12-17
+## [8.0.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-rmcp-v7.0.0...sacp-rmcp-v8.0.0) - 2025-12-17
 
 ### Other
 

--- a/src/sacp-rmcp/Cargo.toml
+++ b/src/sacp-rmcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-rmcp"
-version = "7.0.1"
+version = "8.0.0"
 edition = "2024"
 description = "rmcp integration for SACP proxy components"
 license = "MIT OR Apache-2.0"
@@ -9,7 +9,7 @@ keywords = ["acp", "agent", "proxy", "mcp", "rmcp"]
 categories = ["development-tools"]
 
 [dependencies]
-sacp = { version = "7.0.1", path = "../sacp" }
+sacp = { version = "8.0.0", path = "../sacp" }
 rmcp.workspace = true
 futures.workspace = true
 tokio.workspace = true

--- a/src/sacp-tee/CHANGELOG.md
+++ b/src/sacp-tee/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [7.0.1](https://github.com/symposium-dev/symposium-acp/compare/sacp-tee-v7.0.0...sacp-tee-v7.0.1) - 2025-12-17
+## [8.0.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-tee-v7.0.0...sacp-tee-v8.0.0) - 2025-12-17
 
 ### Other
 

--- a/src/sacp-tee/Cargo.toml
+++ b/src/sacp-tee/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-tee"
-version = "7.0.1"
+version = "8.0.0"
 edition = "2024"
 description = "A debugging proxy that logs all ACP traffic to a file"
 license = "MIT OR Apache-2.0"
@@ -12,8 +12,8 @@ categories = ["development-tools", "development-tools::debugging"]
 anyhow.workspace = true
 chrono.workspace = true
 clap = { workspace = true, features = ["derive"] }
-sacp = { version = "7.0.1", path = "../sacp" }
-sacp-tokio = { version = "7.0.1", path = "../sacp-tokio" }
+sacp = { version = "8.0.0", path = "../sacp" }
+sacp-tokio = { version = "8.0.0", path = "../sacp-tokio" }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 tokio = { workspace = true, features = ["full"] }

--- a/src/sacp-test/CHANGELOG.md
+++ b/src/sacp-test/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [7.0.0](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-test-v7.0.0) - 2025-12-15
+## [8.0.0](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-test-v8.0.0) - 2025-12-15
 
 ### Added
 

--- a/src/sacp-test/Cargo.toml
+++ b/src/sacp-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-test"
-version = "7.0.0"
+version = "8.0.0"
 edition = "2024"
 description = "Test utilities and mock implementations for SACP"
 license = "MIT OR Apache-2.0"
@@ -10,8 +10,8 @@ name = "mcp-echo-server"
 path = "src/bin/mcp_echo_server.rs"
 
 [dependencies]
-sacp = { version = "7.0.1", path = "../sacp" }
-yopo = { version = "7.0.1", path = "../yopo" }
+sacp = { version = "8.0.0", path = "../sacp" }
+yopo = { version = "8.0.0", path = "../yopo" }
 rmcp = { workspace = true, features = ["server"] }
 schemars.workspace = true
 

--- a/src/sacp-tokio/CHANGELOG.md
+++ b/src/sacp-tokio/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [7.0.1](https://github.com/symposium-dev/symposium-acp/compare/sacp-tokio-v7.0.0...sacp-tokio-v7.0.1) - 2025-12-17
+## [8.0.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-tokio-v7.0.0...sacp-tokio-v8.0.0) - 2025-12-17
 
 ### Other
 

--- a/src/sacp-tokio/Cargo.toml
+++ b/src/sacp-tokio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-tokio"
-version = "7.0.1"
+version = "8.0.0"
 edition = "2024"
 description = "Tokio-based utilities for SACP (Symposium's extensions to ACP)"
 license = "MIT OR Apache-2.0"
@@ -9,7 +9,7 @@ keywords = ["acp", "agent", "protocol", "ai", "tokio"]
 categories = ["development-tools"]
 
 [dependencies]
-sacp = { version = "7.0.1", path = "../sacp" }
+sacp = { version = "8.0.0", path = "../sacp" }
 futures.workspace = true
 
 serde.workspace = true

--- a/src/sacp-trace-viewer/Cargo.toml
+++ b/src/sacp-trace-viewer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-trace-viewer"
-version = "7.0.0"
+version = "8.0.0"
 edition = "2024"
 description = "Interactive sequence diagram viewer for SACP trace files"
 license = "MIT OR Apache-2.0"

--- a/src/sacp/CHANGELOG.md
+++ b/src/sacp/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [7.0.1](https://github.com/symposium-dev/symposium-acp/compare/sacp-v7.0.0...sacp-v7.0.1) - 2025-12-17
+## [8.0.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-v7.0.0...sacp-v8.0.0) - 2025-12-17
 
 ### Fixed
 

--- a/src/sacp/Cargo.toml
+++ b/src/sacp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp"
-version = "7.0.1"
+version = "8.0.0"
 edition = "2024"
 description = "Core protocol types and traits for SACP (Symposium's extensions to ACP)"
 license = "MIT OR Apache-2.0"
@@ -10,7 +10,7 @@ categories = ["development-tools"]
 
 [dependencies]
 agent-client-protocol-schema.workspace = true
-sacp-derive = { version = "7.0.0", path = "../sacp-derive" }
+sacp-derive = { version = "8.0.0", path = "../sacp-derive" }
 anyhow.workspace = true
 boxfnonce.workspace = true
 futures.workspace = true

--- a/src/yopo/CHANGELOG.md
+++ b/src/yopo/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [7.0.1](https://github.com/symposium-dev/symposium-acp/compare/yopo-v7.0.0...yopo-v7.0.1) - 2025-12-17
+## [8.0.0](https://github.com/symposium-dev/symposium-acp/compare/yopo-v7.0.0...yopo-v8.0.0) - 2025-12-17
 
 ### Other
 

--- a/src/yopo/Cargo.toml
+++ b/src/yopo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yopo"
-version = "7.0.1"
+version = "8.0.0"
 edition = "2024"
 description = "YOPO (You Only Prompt Once) - A simple ACP client for one-shot prompts"
 license = "MIT OR Apache-2.0"
@@ -14,8 +14,8 @@ name = "yopo"
 path = "src/main.rs"
 
 [dependencies]
-sacp = { version = "7.0.1", path = "../sacp" }
-sacp-tokio = { version = "7.0.1", path = "../sacp-tokio" }
+sacp = { version = "8.0.0", path = "../sacp" }
+sacp-tokio = { version = "8.0.0", path = "../sacp-tokio" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tracing.workspace = true
 tracing-subscriber.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `sacp`: 7.0.0 -> 7.0.1 (✓ API compatible changes)
* `sacp-conductor`: 7.0.0 -> 7.0.1 (✓ API compatible changes)
* `sacp-test`: 7.0.0
* `sacp-tokio`: 7.0.0 -> 7.0.1
* `yopo`: 7.0.0 -> 7.0.1
* `elizacp`: 7.0.0 -> 7.0.1
* `sacp-rmcp`: 7.0.0 -> 7.0.1
* `sacp-tee`: 7.0.0 -> 7.0.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `sacp`

<blockquote>

## [7.0.1](https://github.com/symposium-dev/symposium-acp/compare/sacp-v7.0.0...sacp-v7.0.1) - 2025-12-17

### Fixed

- *(sacp)* add missing HasDefaultEndpoint bounds to handler methods
- *(sacp)* ensure NewSessionRequest flows through handler chain

### Other

- *(sacp)* add tool_fn!() macro for MCP tool registration
</blockquote>

## `sacp-conductor`

<blockquote>

## [7.0.1](https://github.com/symposium-dev/symposium-acp/compare/sacp-conductor-v7.0.0...sacp-conductor-v7.0.1) - 2025-12-17

### Fixed

- *(sacp)* ensure NewSessionRequest flows through handler chain

### Other

- *(sacp)* add tool_fn!() macro for MCP tool registration
</blockquote>

## `sacp-test`

<blockquote>

## [7.0.0](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-test-v7.0.0) - 2025-12-15

### Added

- [**breaking**] introduce role-based connection API
- [**breaking**] change JrMessage trait to take &self and require Clone
- *(sacp-test)* add mcp-echo-server binary for testing
- *(sacp)* add IntoHandled trait for flexible handler return types
- *(sacp-test)* add arrow proxy for testing

### Fixed

- fix cargo.toml metadata, dang it

### Other

- set all crates to version 6.0.0
- release
- cleanup cargo metadata
- replace yolo_prompt with direct yopo::prompt calls
- *(yopo)* return sacp::Error instead of Box<dyn Error>
- *(sacp-test)* use yopo library for test client implementation
- release version 1.0.0 for all crates (sacp-rmcp at 0.8.0)
- Revert to state before 1.0.0 release
- release version 1.0.0 for all crates
- *(sacp)* add Component::serve() and simplify channel API
- [**breaking**] make Component trait ergonomic with async fn and introduce DynComponent
- [**breaking**] make Component the primary trait with Transport as blanket impl
- cleanup and simplify some of the logic to avoid "indirection" through
- unify Transport and Component traits with BoxFuture-returning signatures
- create selective jsonrpcmsg re-export module
- replace jsonrpcmsg::Message with sacp::JsonRpcMessage throughout codebase
- Merge pull request #16 from nikomatsakis/main
- fix doctests for API refactoring
- wip wip wip
- [**breaking**] remove Unpin bounds and simplify transport API
- update all versions from 1.0.0-alpha to 1.0.0-alpha.1
- release v1.0.0-alpha
- *(conductor)* add integration test with arrow proxy and eliza
- *(conductor)* add integration test with arrow proxy and eliza
- rename sacp-doc-test to sacp-test
</blockquote>

## `sacp-tokio`

<blockquote>

## [7.0.1](https://github.com/symposium-dev/symposium-acp/compare/sacp-tokio-v7.0.0...sacp-tokio-v7.0.1) - 2025-12-17

### Other

- updated the following local packages: sacp
</blockquote>

## `yopo`

<blockquote>

## [7.0.1](https://github.com/symposium-dev/symposium-acp/compare/yopo-v7.0.0...yopo-v7.0.1) - 2025-12-17

### Other

- updated the following local packages: sacp, sacp-tokio
</blockquote>

## `elizacp`

<blockquote>

## [7.0.1](https://github.com/symposium-dev/symposium-acp/compare/elizacp-v7.0.0...elizacp-v7.0.1) - 2025-12-17

### Other

- updated the following local packages: sacp, sacp-tokio
</blockquote>

## `sacp-rmcp`

<blockquote>

## [7.0.1](https://github.com/symposium-dev/symposium-acp/compare/sacp-rmcp-v7.0.0...sacp-rmcp-v7.0.1) - 2025-12-17

### Other

- updated the following local packages: sacp
</blockquote>

## `sacp-tee`

<blockquote>

## [7.0.1](https://github.com/symposium-dev/symposium-acp/compare/sacp-tee-v7.0.0...sacp-tee-v7.0.1) - 2025-12-17

### Other

- updated the following local packages: sacp, sacp-tokio
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).