### PR TITLE
chore: release

### DIFF
--- a/src/elizacp/CHANGELOG.md
+++ b/src/elizacp/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [10.0.0](https://github.com/symposium-dev/symposium-acp/compare/elizacp-v9.0.0...elizacp-v10.0.0) - 2025-12-28
+## [10.0.0-alpha.1](https://github.com/symposium-dev/symposium-acp/compare/elizacp-v9.0.0...elizacp-v10.0.0-alpha.1) - 2025-12-28
 
 ### Other
 

--- a/src/elizacp/Cargo.toml
+++ b/src/elizacp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elizacp"
-version = "10.0.0"
+version = "10.0.0-alpha.1"
 edition = "2024"
 description = "Classic Eliza chatbot as an ACP agent for testing"
 license = "MIT OR Apache-2.0"
@@ -16,7 +16,7 @@ path = "src/main.rs"
 test = false
 
 [dependencies]
-sacp = { version = "10.0.0", path = "../sacp" }
+sacp = { version = "10.0.0-alpha.1", path = "../sacp" }
 agent-client-protocol-schema.workspace = true
 anyhow.workspace = true
 clap.workspace = true
@@ -31,7 +31,7 @@ tokio-util.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 uuid.workspace = true
-sacp-tokio = { version = "10.0.0", path = "../sacp-tokio" }
+sacp-tokio = { version = "10.0.0-alpha.1", path = "../sacp-tokio" }
 
 [dev-dependencies]
 expect-test.workspace = true

--- a/src/sacp-conductor/CHANGELOG.md
+++ b/src/sacp-conductor/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [10.0.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-conductor-v9.0.0...sacp-conductor-v10.0.0) - 2025-12-28
+## [10.0.0-alpha.1](https://github.com/symposium-dev/symposium-acp/compare/sacp-conductor-v9.0.0...sacp-conductor-v10.0.0-alpha.1) - 2025-12-28
 
 ### Added
 

--- a/src/sacp-conductor/Cargo.toml
+++ b/src/sacp-conductor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-conductor"
-version = "10.0.0"
+version = "10.0.0-alpha.1"
 edition = "2024"
 description = "Conductor for orchestrating SACP proxy chains"
 license = "MIT OR Apache-2.0"
@@ -12,9 +12,9 @@ categories = ["development-tools"]
 test-support = []
 
 [dependencies]
-sacp = { version = "10.0.0", path = "../sacp" }
-sacp-tokio = { version = "10.0.0", path = "../sacp-tokio" }
-sacp-trace-viewer = { version = "9.0.0", path = "../sacp-trace-viewer" }
+sacp = { version = "10.0.0-alpha.1", path = "../sacp" }
+sacp-tokio = { version = "10.0.0-alpha.1", path = "../sacp-tokio" }
+sacp-trace-viewer = { version = "10.0.0-alpha.1", path = "../sacp-trace-viewer" }
 agent-client-protocol-schema.workspace = true
 anyhow.workspace = true
 axum.workspace = true

--- a/src/sacp-derive/CHANGELOG.md
+++ b/src/sacp-derive/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [9.0.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-derive-v8.0.0...sacp-derive-v9.0.0) - 2025-12-19
+## [10.0.0-alpha.1](https://github.com/symposium-dev/symposium-acp/compare/sacp-derive-v8.0.0...sacp-derive-v10.0.0-alpha.1) - 2025-12-19
 
 ### Added
 

--- a/src/sacp-derive/Cargo.toml
+++ b/src/sacp-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-derive"
-version = "9.0.0"
+version = "10.0.0-alpha.1"
 edition = "2024"
 description = "Derive macros for SACP JSON-RPC traits"
 license = "MIT OR Apache-2.0"

--- a/src/sacp-rmcp/CHANGELOG.md
+++ b/src/sacp-rmcp/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [10.0.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-rmcp-v9.0.0...sacp-rmcp-v10.0.0) - 2025-12-28
+## [10.0.0-alpha.1](https://github.com/symposium-dev/symposium-acp/compare/sacp-rmcp-v9.0.0...sacp-rmcp-v10.0.0-alpha.1) - 2025-12-28
 
 ### Other
 

--- a/src/sacp-rmcp/Cargo.toml
+++ b/src/sacp-rmcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-rmcp"
-version = "10.0.0"
+version = "10.0.0-alpha.1"
 edition = "2024"
 description = "rmcp integration for SACP proxy components"
 license = "MIT OR Apache-2.0"
@@ -9,7 +9,7 @@ keywords = ["acp", "agent", "proxy", "mcp", "rmcp"]
 categories = ["development-tools"]
 
 [dependencies]
-sacp = { version = "10.0.0", path = "../sacp" }
+sacp = { version = "10.0.0-alpha.1", path = "../sacp" }
 rmcp.workspace = true
 futures.workspace = true
 tokio.workspace = true

--- a/src/sacp-tee/CHANGELOG.md
+++ b/src/sacp-tee/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [10.0.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-tee-v9.0.0...sacp-tee-v10.0.0) - 2025-12-28
+## [10.0.0-alpha.1](https://github.com/symposium-dev/symposium-acp/compare/sacp-tee-v9.0.0...sacp-tee-v10.0.0-alpha.1) - 2025-12-28
 
 ### Other
 

--- a/src/sacp-tee/Cargo.toml
+++ b/src/sacp-tee/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-tee"
-version = "10.0.0"
+version = "10.0.0-alpha.1"
 edition = "2024"
 description = "A debugging proxy that logs all ACP traffic to a file"
 license = "MIT OR Apache-2.0"
@@ -12,8 +12,8 @@ categories = ["development-tools", "development-tools::debugging"]
 anyhow.workspace = true
 chrono.workspace = true
 clap = { workspace = true, features = ["derive"] }
-sacp = { version = "10.0.0", path = "../sacp" }
-sacp-tokio = { version = "10.0.0", path = "../sacp-tokio" }
+sacp = { version = "10.0.0-alpha.1", path = "../sacp" }
+sacp-tokio = { version = "10.0.0-alpha.1", path = "../sacp-tokio" }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 tokio = { workspace = true, features = ["full"] }

--- a/src/sacp-test/CHANGELOG.md
+++ b/src/sacp-test/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [9.0.0](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-test-v9.0.0) - 2025-12-15
+## [10.0.0-alpha.1](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-test-v10.0.0-alpha.1) - 2025-12-15
 
 ### Added
 

--- a/src/sacp-test/Cargo.toml
+++ b/src/sacp-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-test"
-version = "9.0.0"
+version = "10.0.0-alpha.1"
 edition = "2024"
 description = "Test utilities and mock implementations for SACP"
 license = "MIT OR Apache-2.0"
@@ -10,8 +10,8 @@ name = "mcp-echo-server"
 path = "src/bin/mcp_echo_server.rs"
 
 [dependencies]
-sacp = { version = "10.0.0", path = "../sacp" }
-yopo = { version = "10.0.0", path = "../yopo" }
+sacp = { version = "10.0.0-alpha.1", path = "../sacp" }
+yopo = { version = "10.0.0-alpha.1", path = "../yopo" }
 rmcp = { workspace = true, features = ["server"] }
 schemars.workspace = true
 

--- a/src/sacp-tokio/CHANGELOG.md
+++ b/src/sacp-tokio/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [10.0.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-tokio-v9.0.0...sacp-tokio-v10.0.0) - 2025-12-28
+## [10.0.0-alpha.1](https://github.com/symposium-dev/symposium-acp/compare/sacp-tokio-v9.0.0...sacp-tokio-v10.0.0-alpha.1) - 2025-12-28
 
 ### Other
 

--- a/src/sacp-tokio/Cargo.toml
+++ b/src/sacp-tokio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-tokio"
-version = "10.0.0"
+version = "10.0.0-alpha.1"
 edition = "2024"
 description = "Tokio-based utilities for SACP (Symposium's extensions to ACP)"
 license = "MIT OR Apache-2.0"
@@ -9,7 +9,7 @@ keywords = ["acp", "agent", "protocol", "ai", "tokio"]
 categories = ["development-tools"]
 
 [dependencies]
-sacp = { version = "10.0.0", path = "../sacp" }
+sacp = { version = "10.0.0-alpha.1", path = "../sacp" }
 futures.workspace = true
 
 serde.workspace = true

--- a/src/sacp-trace-viewer/Cargo.toml
+++ b/src/sacp-trace-viewer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-trace-viewer"
-version = "9.0.0"
+version = "10.0.0-alpha.1"
 edition = "2024"
 description = "Interactive sequence diagram viewer for SACP trace files"
 license = "MIT OR Apache-2.0"

--- a/src/sacp/CHANGELOG.md
+++ b/src/sacp/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [10.0.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-v9.0.0...sacp-v10.0.0) - 2025-12-28
+## [10.0.0-alpha.1](https://github.com/symposium-dev/symposium-acp/compare/sacp-v9.0.0...sacp-v10.0.0-alpha.1) - 2025-12-28
 
 ### Added
 

--- a/src/sacp/Cargo.toml
+++ b/src/sacp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp"
-version = "10.0.0"
+version = "10.0.0-alpha.1"
 edition = "2024"
 description = "Core protocol types and traits for SACP (Symposium's extensions to ACP)"
 license = "MIT OR Apache-2.0"
@@ -10,7 +10,7 @@ categories = ["development-tools"]
 
 [dependencies]
 agent-client-protocol-schema.workspace = true
-sacp-derive = { version = "9.0.0", path = "../sacp-derive" }
+sacp-derive = { version = "10.0.0-alpha.1", path = "../sacp-derive" }
 anyhow.workspace = true
 boxfnonce.workspace = true
 futures.workspace = true

--- a/src/yopo/CHANGELOG.md
+++ b/src/yopo/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [10.0.0](https://github.com/symposium-dev/symposium-acp/compare/yopo-v9.0.0...yopo-v10.0.0) - 2025-12-28
+## [10.0.0-alpha.1](https://github.com/symposium-dev/symposium-acp/compare/yopo-v9.0.0...yopo-v10.0.0-alpha.1) - 2025-12-28
 
 ### Other
 

--- a/src/yopo/Cargo.toml
+++ b/src/yopo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yopo"
-version = "10.0.0"
+version = "10.0.0-alpha.1"
 edition = "2024"
 description = "YOPO (You Only Prompt Once) - A simple ACP client for one-shot prompts"
 license = "MIT OR Apache-2.0"
@@ -14,8 +14,8 @@ name = "yopo"
 path = "src/main.rs"
 
 [dependencies]
-sacp = { version = "10.0.0", path = "../sacp" }
-sacp-tokio = { version = "10.0.0", path = "../sacp-tokio" }
+sacp = { version = "10.0.0-alpha.1", path = "../sacp" }
+sacp-tokio = { version = "10.0.0-alpha.1", path = "../sacp-tokio" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tracing.workspace = true
 tracing-subscriber.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `sacp`: 9.0.0 -> 10.0.0 (⚠ API breaking changes)
* `sacp-tokio`: 9.0.0 -> 10.0.0 (✓ API compatible changes)
* `sacp-conductor`: 9.0.0 -> 10.0.0 (⚠ API breaking changes)
* `yopo`: 9.0.0 -> 10.0.0 (✓ API compatible changes)
* `sacp-test`: 9.0.0
* `elizacp`: 9.0.0 -> 10.0.0 (✓ API compatible changes)
* `sacp-rmcp`: 9.0.0 -> 10.0.0 (✓ API compatible changes)
* `sacp-tee`: 9.0.0 -> 10.0.0 (✓ API compatible changes)

### ⚠ `sacp` breaking changes

```text
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/enum_missing.ron

Failed in:
  enum sacp::role::RemoteRoleStyle, previously in file /tmp/.tmpvksC14/sacp/src/role.rs:75

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/inherent_method_missing.ron

Failed in:
  JrResponse::await_when_ok_response_received, previously in file /tmp/.tmpvksC14/sacp/src/jsonrpc.rs:2692
  JrResponse::await_when_result_received, previously in file /tmp/.tmpvksC14/sacp/src/jsonrpc.rs:2767
  JrConnectionBuilder::with_client, previously in file /tmp/.tmpvksC14/sacp/src/jsonrpc.rs:1107
  JrConnection::with_client, previously in file /tmp/.tmpvksC14/sacp/src/jsonrpc.rs:1243
  SessionBuilder::run_session, previously in file /tmp/.tmpvksC14/sacp/src/session.rs:127
  SessionBuilder::send_request, previously in file /tmp/.tmpvksC14/sacp/src/session.rs:157

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/module_missing.ron

Failed in:
  mod sacp::role, previously in file /tmp/.tmpvksC14/sacp/src/role.rs:1

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/struct_missing.ron

Failed in:
  struct sacp::role::Client, previously in file /tmp/.tmpvksC14/sacp/src/role.rs:179
  struct sacp::Client, previously in file /tmp/.tmpvksC14/sacp/src/role.rs:179
  struct sacp::role::ProxyToConductorState, previously in file /tmp/.tmpvksC14/sacp/src/role.rs:353
  struct sacp::role::ConductorToProxy, previously in file /tmp/.tmpvksC14/sacp/src/role.rs:311
  struct sacp::role::AgentToClient, previously in file /tmp/.tmpvksC14/sacp/src/role.rs:269
  struct sacp::role::ProxyToConductor, previously in file /tmp/.tmpvksC14/sacp/src/role.rs:349
  struct sacp::role::Conductor, previously in file /tmp/.tmpvksC14/sacp/src/role.rs:191
  struct sacp::Conductor, previously in file /tmp/.tmpvksC14/sacp/src/role.rs:191
  struct sacp::handler::NotificationHandler, previously in file /tmp/.tmpvksC14/sacp/src/jsonrpc/handlers.rs:180
  struct sacp::mcp_server::McpMessageHandler, previously in file /tmp/.tmpvksC14/sacp/src/mcp_server/server.rs:90
  struct sacp::role::Agent, previously in file /tmp/.tmpvksC14/sacp/src/role.rs:185
  struct sacp::Agent, previously in file /tmp/.tmpvksC14/sacp/src/role.rs:185
  struct sacp::mcp_server::ToolFnResponder, previously in file /tmp/.tmpvksC14/sacp/src/mcp_server/responder.rs:16
  struct sacp::handler::ChainedHandler, previously in file /tmp/.tmpvksC14/sacp/src/jsonrpc/handlers.rs:462
  struct sacp::handler::NamedHandler, previously in file /tmp/.tmpvksC14/sacp/src/jsonrpc/handlers.rs:421
  struct sacp::role::ConductorToAgent, previously in file /tmp/.tmpvksC14/sacp/src/role.rs:328
  struct sacp::role::ConductorToClient, previously in file /tmp/.tmpvksC14/sacp/src/role.rs:286
  struct sacp::handler::RequestHandler, previously in file /tmp/.tmpvksC14/sacp/src/jsonrpc/handlers.rs:46
  struct sacp::role::ClientToAgent, previously in file /tmp/.tmpvksC14/sacp/src/role.rs:230
  struct sacp::mcp_server::ToolCall, previously in file /tmp/.tmpvksC14/sacp/src/mcp_server/responder.rs:8
  struct sacp::role::UntypedEndpoint, previously in file /tmp/.tmpvksC14/sacp/src/role.rs:173
  struct sacp::handler::MessageHandler, previously in file /tmp/.tmpvksC14/sacp/src/jsonrpc/handlers.rs:305
  struct sacp::role::UntypedRole, previously in file /tmp/.tmpvksC14/sacp/src/role.rs:205

--- failure trait_associated_type_added: non-sealed public trait added associated type without default value ---

Description:
A non-sealed trait has gained an associated type without a default value, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-item-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/trait_associated_type_added.ron

Failed in:
  trait associated type sacp::JrMessageHandler::Link in file /tmp/.tmp7oQS3Q/symposium-acp/src/sacp/src/jsonrpc.rs:176

--- failure trait_missing: pub trait removed or renamed ---

Description:
A publicly-visible trait cannot be imported by its prior path. A `pub use` may have been removed, or the trait itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/trait_missing.ron

Failed in:
  trait sacp::role::HasDefaultEndpoint, previously in file /tmp/.tmpvksC14/sacp/src/role.rs:61
  trait sacp::HasDefaultEndpoint, previously in file /tmp/.tmpvksC14/sacp/src/role.rs:61
  trait sacp::role::JrEndpoint, previously in file /tmp/.tmpvksC14/sacp/src/role.rs:64
  trait sacp::JrEndpoint, previously in file /tmp/.tmpvksC14/sacp/src/role.rs:64
  trait sacp::role::HasEndpoint, previously in file /tmp/.tmpvksC14/sacp/src/role.rs:67
  trait sacp::HasEndpoint, previously in file /tmp/.tmpvksC14/sacp/src/role.rs:67
  trait sacp::role::JrRole, previously in file /tmp/.tmpvksC14/sacp/src/role.rs:28
  trait sacp::JrRole, previously in file /tmp/.tmpvksC14/sacp/src/role.rs:28

--- failure trait_removed_associated_type: trait's associated type was removed ---

Description:
A public trait's associated type was removed or renamed.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/trait_removed_associated_type.ron

Failed in:
  associated type JrMessageHandler::Role, previously at /tmp/.tmpvksC14/sacp/src/jsonrpc.rs:175

--- failure trait_requires_more_generic_type_params: trait now requires more generic type parameters ---

Description:
A trait now requires more generic type parameters than it used to. Uses of this trait that supplied the previously-required number of generic types will be broken. To fix this, consider supplying default values for newly-added generic types.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-parameter-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/trait_requires_more_generic_type_params.ron

Failed in:
  trait DynComponent (0 -> 1 required generic types) in /tmp/.tmp7oQS3Q/symposium-acp/src/sacp/src/component.rs:219
  trait DynComponent (0 -> 1 required generic types) in /tmp/.tmp7oQS3Q/symposium-acp/src/sacp/src/component.rs:219

--- failure type_mismatched_generic_lifetimes: type now takes a different number of generic lifetimes ---

Description:
A type now takes a different number of generic lifetime parameters. Uses of this type that name the previous number of parameters will be broken.
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/type_mismatched_generic_lifetimes.ron
Failed in:
  Struct ActiveSession (0 -> 1 lifetime params) in /tmp/.tmp7oQS3Q/symposium-acp/src/sacp/src/session.rs:431

--- failure type_requires_more_generic_type_params: type now requires more generic type parameters ---

Description:
A type now requires more generic type parameters than it used to. Uses of this type that supplied the previously-required number of generic types will be broken. To fix this, consider supplying default values for newly-added generic types.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-parameter-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/type_requires_more_generic_type_params.ron

Failed in:
  Struct DynComponent (0 -> 1 required generic types) in /tmp/.tmp7oQS3Q/symposium-acp/src/sacp/src/component.rs:219
  Struct DynComponent (0 -> 1 required generic types) in /tmp/.tmp7oQS3Q/symposium-acp/src/sacp/src/component.rs:219
```

### ⚠ `sacp-conductor` breaking changes

```text
--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant ConductorCommand::Mcp 1 -> 2 in /tmp/.tmp7oQS3Q/symposium-acp/src/sacp-conductor/src/lib.rs:246

--- failure enum_struct_variant_field_added: pub enum struct variant field added ---

Description:
An enum's exhaustive struct variant has a new field, which has to be included when constructing or matching on this variant.
        ref: https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/enum_struct_variant_field_added.ron

Failed in:
  field components of variant ConductorCommand::Agent in /tmp/.tmp7oQS3Q/symposium-acp/src/sacp-conductor/src/lib.rs:232

--- failure enum_struct_variant_field_missing: pub enum struct variant's field removed or renamed ---

Description:
A publicly-visible enum has a struct variant whose field is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/enum_struct_variant_field_missing.ron

Failed in:
  field proxies of variant ConductorCommand::Agent, previously in file /tmp/.tmpvksC14/sacp-conductor/src/lib.rs:167

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/enum_variant_added.ron

Failed in:
  variant ConductorCommand:Proxy in /tmp/.tmp7oQS3Q/symposium-acp/src/sacp-conductor/src/lib.rs:236
  variant SourceComponentIndex:Successor in /tmp/.tmp7oQS3Q/symposium-acp/src/sacp-conductor/src/conductor.rs:1101
  variant SourceComponentIndex:Proxy in /tmp/.tmp7oQS3Q/symposium-acp/src/sacp-conductor/src/conductor.rs:1104

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/enum_variant_missing.ron

Failed in:
  variant SourceComponentIndex::ConductorSuccessor, previously in file /tmp/.tmpvksC14/sacp-conductor/src/conductor.rs:1306
  variant SourceComponentIndex::Component, previously in file /tmp/.tmpvksC14/sacp-conductor/src/conductor.rs:1309

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/method_parameter_count_changed.ron

Failed in:
  sacp_conductor::Conductor::new now takes 4 parameters instead of 3, in /tmp/.tmp7oQS3Q/symposium-acp/src/sacp-conductor/src/conductor.rs:165

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/struct_missing.ron

Failed in:
  struct sacp_conductor::ConductorMessageHandler, previously in file /tmp/.tmpvksC14/sacp-conductor/src/conductor.rs:243

--- failure trait_missing: pub trait removed or renamed ---

Description:
A publicly-visible trait cannot be imported by its prior path. A `pub use` may have been removed, or the trait itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/trait_missing.ron

Failed in:
  trait sacp_conductor::ComponentList, previously in file /tmp/.tmpvksC14/sacp-conductor/src/conductor.rs:1344

--- failure trait_requires_more_generic_type_params: trait now requires more generic type parameters ---

Description:
A trait now requires more generic type parameters than it used to. Uses of this trait that supplied the previously-required number of generic types will be broken. To fix this, consider supplying default values for newly-added generic types.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-parameter-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/trait_requires_more_generic_type_params.ron

Failed in:
  trait ConductorResponder (0 -> 1 required generic types) in /tmp/.tmp7oQS3Q/symposium-acp/src/sacp-conductor/src/conductor.rs:347
  trait Conductor (0 -> 1 required generic types) in /tmp/.tmp7oQS3Q/symposium-acp/src/sacp-conductor/src/conductor.rs:156

--- failure type_requires_more_generic_type_params: type now requires more generic type parameters ---

Description:
A type now requires more generic type parameters than it used to. Uses of this type that supplied the previously-required number of generic types will be broken. To fix this, consider supplying default values for newly-added generic types.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-parameter-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/type_requires_more_generic_type_params.ron

Failed in:
  Struct ConductorResponder (0 -> 1 required generic types) in /tmp/.tmp7oQS3Q/symposium-acp/src/sacp-conductor/src/conductor.rs:347
  Struct Conductor (0 -> 1 required generic types) in /tmp/.tmp7oQS3Q/symposium-acp/src/sacp-conductor/src/conductor.rs:156
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `sacp`

<blockquote>

## [10.0.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-v9.0.0...sacp-v10.0.0) - 2025-12-28

### Added

- *(sacp)* add LocalRole associated type to JrLink
- *(sacp)* add on_proxy_session_start and return SessionId from start_session_proxy
- *(sacp)* add on_session_start for spawned sessions
- *(sacp)* add proxy_session for per-session MCP server injection
- *(sacp)* add build_session_from for proxying session requests
- *(sacp)* make tool_fn run concurrently
- *(sacp)* add tool_fn for concurrent stateless tools

### Fixed

- *(sacp)* use unstructured output for non-object MCP tool results
- *(sacp)* resolve race condition in proxy_remaining_messages

### Other

- [**breaking**] add ProxyPeer and improve link documentation
- [**breaking**] split peer.rs into separate peer and link modules
- [**breaking**] update module and documentation references from role to peer
- [**breaking**] rename FooRole types to FooPeer
- [**breaking**] replace RemotePeer with HasDefaultPeer::DefaultPeer
- [**breaking**] remove LocalRole from JrLink trait
- [**breaking**] rename link endpoint types from Foo to FooRole
- [**breaking**] give component a link
- [**breaking**] split Conductor into agent vs proxy mode with ConductorLink trait
- [**breaking**] rename End type param to Peer, endpoint vars to peer
- [**breaking**] more endpoint -> peer renames
- update UntypedRole to UntypedLink in doc examples
- [**breaking**] rename Endpoint to Role
- *(sacp)* rename JrRole to JrLink, Role type param to Link
- [**breaking**] rename JrRole to JrLink (and the Role associated type to Link)
- *(deps)* upgrade rmcp to 0.12.0
- *(sacp-conductor)* use explicit endpoints for ConductorToClient
- better debug logging
- cleanup the proxying code
- *(sacp)* fix cookbook doctest for start_session_proxy
- *(sacp)* add block_task() builder pattern for SessionBuilder
- *(sacp)* rename spawn_session to start_session
- *(sacp)* rename with_client to run_until
- *(sacp)* add lifetime-safe session proxying API
- *(sacp)* make all cookbook doctests compile and run
- *(sacp)* make cookbook examples compile
- *(sacp)* add cookbook module with common patterns
- update references for renamed methods
- *(sacp)* simplify McpServer handler architecture
- rename to McpNewSessionHandler for clarity
- *(sacp)* reduce public API surface for handler types
- *(sacp)* extract process_stream_concurrently utility
</blockquote>

## `sacp-tokio`

<blockquote>

## [10.0.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-tokio-v9.0.0...sacp-tokio-v10.0.0) - 2025-12-28

### Other

- [**breaking**] split peer.rs into separate peer and link modules
- [**breaking**] update module and documentation references from role to peer
- [**breaking**] give component a link
- update UntypedRole to UntypedLink in doc examples
- *(sacp)* rename with_client to run_until
- update references for renamed methods
</blockquote>

## `sacp-conductor`

<blockquote>

## [10.0.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-conductor-v9.0.0...sacp-conductor-v10.0.0) - 2025-12-28

### Added

- *(sacp)* add tool_fn for concurrent stateless tools

### Fixed

- *(sacp)* use unstructured output for non-object MCP tool results
- *(sacp-conductor)* route proxied responses through conductor message loop
- *(sacp-conductor)* use Agent endpoint for proxy mode successor forwarding

### Other

- [**breaking**] split peer.rs into separate peer and link modules
- [**breaking**] update module and documentation references from role to peer
- [**breaking**] rename FooRole types to FooPeer
- [**breaking**] rename link endpoint types from Foo to FooRole
- [**breaking**] give component a link
- refactor!(conductor): replace ComponentList with typed instantiator traits
- [**breaking**] split Conductor into agent vs proxy mode with ConductorLink trait
- use self.conductor_tx
- [**breaking**] rename End type param to Peer, endpoint vars to peer
- update UntypedRole to UntypedLink in doc examples
- [**breaking**] rename Endpoint to Role
- *(sacp)* rename JrRole to JrLink, Role type param to Link
- [**breaking**] rename JrRole to JrLink (and the Role associated type to Link)
- *(sacp-conductor)* use explicit endpoints for ConductorToClient
- *(sacp)* add block_task() builder pattern for SessionBuilder
- *(sacp)* rename with_client to run_until
- update references for renamed methods
</blockquote>

## `yopo`

<blockquote>

## [10.0.0](https://github.com/symposium-dev/symposium-acp/compare/yopo-v9.0.0...yopo-v10.0.0) - 2025-12-28

### Other

- [**breaking**] split peer.rs into separate peer and link modules
- [**breaking**] update module and documentation references from role to peer
- [**breaking**] give component a link
- *(sacp)* add block_task() builder pattern for SessionBuilder
- *(sacp)* rename spawn_session to start_session
- *(sacp)* rename with_client to run_until
- *(sacp)* add lifetime-safe session proxying API
</blockquote>

## `sacp-test`

<blockquote>

## [9.0.0](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-test-v9.0.0) - 2025-12-15

### Added

- [**breaking**] introduce role-based connection API
- [**breaking**] change JrMessage trait to take &self and require Clone
- *(sacp-test)* add mcp-echo-server binary for testing
- *(sacp)* add IntoHandled trait for flexible handler return types
- *(sacp-test)* add arrow proxy for testing

### Fixed

- fix cargo.toml metadata, dang it

### Other

- set all crates to version 6.0.0
- release
- cleanup cargo metadata
- replace yolo_prompt with direct yopo::prompt calls
- *(yopo)* return sacp::Error instead of Box<dyn Error>
- *(sacp-test)* use yopo library for test client implementation
- release version 1.0.0 for all crates (sacp-rmcp at 0.8.0)
- Revert to state before 1.0.0 release
- release version 1.0.0 for all crates
- *(sacp)* add Component::serve() and simplify channel API
- [**breaking**] make Component trait ergonomic with async fn and introduce DynComponent
- [**breaking**] make Component the primary trait with Transport as blanket impl
- cleanup and simplify some of the logic to avoid "indirection" through
- unify Transport and Component traits with BoxFuture-returning signatures
- create selective jsonrpcmsg re-export module
- replace jsonrpcmsg::Message with sacp::JsonRpcMessage throughout codebase
- Merge pull request #16 from nikomatsakis/main
- fix doctests for API refactoring
- wip wip wip
- [**breaking**] remove Unpin bounds and simplify transport API
- update all versions from 1.0.0-alpha to 1.0.0-alpha.1
- release v1.0.0-alpha
- *(conductor)* add integration test with arrow proxy and eliza
- *(conductor)* add integration test with arrow proxy and eliza
- rename sacp-doc-test to sacp-test
</blockquote>

## `elizacp`

<blockquote>

## [10.0.0](https://github.com/symposium-dev/symposium-acp/compare/elizacp-v9.0.0...elizacp-v10.0.0) - 2025-12-28

### Other

- [**breaking**] split peer.rs into separate peer and link modules
- [**breaking**] update module and documentation references from role to peer
- [**breaking**] give component a link
- update UntypedRole to UntypedLink in doc examples
- *(sacp)* rename with_client to run_until
- update references for renamed methods
</blockquote>

## `sacp-rmcp`

<blockquote>

## [10.0.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-rmcp-v9.0.0...sacp-rmcp-v10.0.0) - 2025-12-28

### Other

- [**breaking**] rename FooRole types to FooPeer
- [**breaking**] rename link endpoint types from Foo to FooRole
- [**breaking**] give component a link
- [**breaking**] rename Endpoint to Role
- *(sacp)* rename JrRole to JrLink, Role type param to Link
- [**breaking**] rename JrRole to JrLink (and the Role associated type to Link)
</blockquote>

## `sacp-tee`

<blockquote>

## [10.0.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-tee-v9.0.0...sacp-tee-v10.0.0) - 2025-12-28

### Other

- [**breaking**] split peer.rs into separate peer and link modules
- [**breaking**] update module and documentation references from role to peer
- [**breaking**] give component a link
- [**breaking**] rename JrRole to JrLink (and the Role associated type to Link)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).