### PR TITLE
refactor(sacp): add lifetime-safe session proxying API

### DIFF
--- a/src/yopo/src/lib.rs
+++ b/src/yopo/src/lib.rs
@@ -2,13 +2,13 @@
 //!
 //! Provides a convenient API for running one-shot prompts against SACP components.
 
+use sacp::ClientToAgent;
 use sacp::schema::{
     AudioContent, ContentBlock, EmbeddedResourceResource, ImageContent, InitializeRequest,
     RequestPermissionOutcome, RequestPermissionRequest, RequestPermissionResponse,
     SessionNotification, TextContent, VERSION as PROTOCOL_VERSION,
 };
 use sacp::util::MatchMessage;
-use sacp::{ClientToAgent, JrResponder};
 use sacp::{Component, Handled, MessageCx, UntypedMessage};
 use std::path::PathBuf;
 
@@ -113,10 +113,7 @@ pub async fn prompt_with_callback(
                 .block_task()
                 .await?;
 
-            let mut session = cx
-                .build_session(PathBuf::from("."))
-                .send_request(JrResponder::run)
-                .await?;
+            let mut session = cx.build_session(PathBuf::from(".")).spawn_session().await?;
 
             session.send_prompt(prompt_text)?;
 


### PR DESCRIPTION
ActiveSession now has a 'responder lifetime that encodes whether responders are still active. This prevents calling proxy_remaining_messages() on sessions from run_session() where responders would die on return.

New APIs:
- ActiveSession::response() - builds NewSessionResponse for forwarding
- ActiveSession::proxy_remaining_messages() - only on 'static sessions
- SessionBuilder::spawn_session_proxy() - convenience for inject + proxy

Removed SessionBuilder::proxy_session() which was an anti-pattern that combined too many concerns.

Updated cookbook with both simple (spawn_session_proxy) and advanced (spawn_session + proxy_remaining_messages) patterns.