### PR TITLE
docs: improve sacp crate documentation for newcomers

### DIFF
--- a/commit-messages.txt
+++ b/commit-messages.txt
@@ -1,0 +1,129 @@
+# Improved commit messages for e8bbda18b3e2b9484a15dfab0cc4a7ffa30d4710..HEAD
+# Use: git rebase -i e8bbda18b3e2b9484a15dfab0cc4a7ffa30d4710
+# Then for each commit, copy the corresponding message below.
+
+================================================================================
+COMMIT 1: bae4a8f - refactor!: rename roles to FooRole
+================================================================================
+
+refactor!: rename link endpoint types from Foo to FooRole
+
+Rename the endpoint marker types to clarify they represent roles in a connection:
+- Client -> ClientRole
+- Agent -> AgentRole
+- Conductor -> ConductorRole
+- Untyped -> UntypedRole
+
+This is preparation for separating the concepts of "role" (who I am) from
+"peer" (who I'm talking to) and "link" (the relationship between two sides).
+
+BREAKING CHANGE: All references to Client, Agent, Conductor, Untyped as
+peer types must be updated to ClientRole, AgentRole, etc.
+
+================================================================================
+COMMIT 2: f9b9a5a - refactor!: remove local role
+================================================================================
+
+refactor!: remove LocalRole from JrLink trait
+
+The LocalRole associated type on JrLink was redundant - it captured "who am I"
+but that information is already implicit in the link type itself (e.g.,
+ClientToAgent implies the local side is a client).
+
+This simplifies the trait and removes unnecessary type parameters from
+connection handling code.
+
+BREAKING CHANGE: JrLink no longer has a LocalRole associated type.
+
+================================================================================
+COMMIT 3: 4de0fec - refactor!: move RemotePeer to DefaultPeer
+================================================================================
+
+refactor!: replace RemotePeer with HasDefaultPeer::DefaultPeer
+
+Move the "default peer" concept from JrLink::RemotePeer to a separate
+HasDefaultPeer trait with DefaultPeer associated type.
+
+This separation is important because:
+- Not all links have a single default peer (e.g., ProxyToConductor can
+  send to both ClientPeer and AgentPeer)
+- Links that DO have a default peer now explicitly implement HasDefaultPeer
+- The HasPeer<P> trait declares which peers a link can communicate with
+
+BREAKING CHANGE: JrLink::RemotePeer removed; implement HasDefaultPeer instead.
+
+================================================================================
+COMMIT 4: f3815bc - refactor!: rename Role to Peer
+================================================================================
+
+refactor!: rename FooRole types to FooPeer
+
+Complete the terminology shift from "role" to "peer":
+- ClientRole -> ClientPeer
+- AgentRole -> AgentPeer
+- ConductorRole -> ConductorPeer
+- UntypedRole -> UntypedPeer
+- JrRole trait -> JrPeer trait
+
+"Peer" better captures what these types represent: the logical destination
+for messages. A peer is "who you're talking to", not "who you are".
+
+BREAKING CHANGE: All FooRole types renamed to FooPeer.
+
+================================================================================
+COMMIT 5: 24ec6c4 - refactor!: s/role/peer
+================================================================================
+
+refactor!: update module and documentation references from role to peer
+
+Rename the role module to peer module and update all references:
+- sacp::role:: -> sacp::peer::
+- role.rs -> peer.rs
+- Doc comments updated to use "peer" terminology
+
+Also updates documentation to use clearer language:
+- "fulfill their role" -> "fulfill their responsibilities"
+- "role-agnostic" -> "link-agnostic"
+
+BREAKING CHANGE: sacp::role module renamed to sacp::peer.
+
+================================================================================
+COMMIT 6: 1689112 - refactor!: split peer/link modules
+================================================================================
+
+refactor!: split peer.rs into separate peer and link modules
+
+The peer module was conflating two distinct concepts:
+- Peers: logical message destinations (ClientPeer, AgentPeer, etc.)
+- Links: directional connection types (ClientToAgent, AgentToClient, etc.)
+
+Now split into:
+- peer.rs: JrPeer trait and peer types (ClientPeer, AgentPeer, ConductorPeer)
+- link.rs: JrLink trait, HasDefaultPeer, HasPeer, RemoteStyle, and all
+  link types (ClientToAgent, AgentToClient, ProxyToConductor, etc.)
+
+This clarifies the mental model:
+- Links capture the *relationship* between two sides
+- Peers identify *who* you're talking to
+
+BREAKING CHANGE: Link types moved from sacp::peer to sacp::link.
+
+================================================================================
+COMMIT 7: 48390ea - refactor!: more comments, introduce ProxyPeer
+================================================================================
+
+refactor!: add ProxyPeer and improve link documentation
+
+Introduce ProxyPeer as a distinct peer type for proxy connections, used by
+ConductorToProxy. Previously this incorrectly used AgentPeer as the default.
+
+Also adds extensive documentation to link types explaining:
+- When each link type should be used
+- Which link types are conductor-internal vs. general purpose
+- The relationship between ConductorToProxy and ClientToAgent
+- How SuccessorMessage routing works
+
+Key documentation additions:
+- ClientToAgent: "Use this when attempting to issue prompts or requests"
+- AgentToClient: "This is used when implementing agents"
+- ConductorTo* links: "Only meant to be used by the conductor itself"

--- a/src/sacp/README.md
+++ b/src/sacp/README.md
@@ -1,54 +1,66 @@
 # sacp -- the Symposium Agent Client Protocol (ACP) SDK
 
-**sacp** is a Rust SDK for building agents and editors using the [Agent-Client Protocol (ACP)](https://agentclientprotocol.com/). It makes it easy to build ACP editors and clients -- or, indeed, any JSON-RPC-based application.
+**sacp** is a Rust SDK for building [Agent-Client Protocol (ACP)](https://agentclientprotocol.com/) applications.
+ACP is a protocol for communication between AI agents and their clients (IDEs, CLIs, etc.),
+enabling features like tool use, permission requests, and streaming responses.
 
-## Quick Start
+## What can you build with sacp?
 
-Building an ACP agent is straightforward with sacp's type-safe API:
+- **Clients** that talk to ACP agents (like building your own Claude Code interface)
+- **Proxies** that add capabilities to existing agents (like adding custom tools via MCP)
+- **Agents** that respond to prompts with AI-powered responses
+
+## Quick Start: Connecting to an Agent
+
+The most common use case is connecting to an existing ACP agent as a client:
 
 ```rust
-// Start by creating an agent talking on stdout/stdin
-JrConnection::new(
-    tokio::io::stdout().compat_write(),
-    tokio::io::stdin().compat(),
-)
-.name("my-agent") // Give it a name for logging purposes
-.on_receive_request(async move |initialize: InitializeRequest, request_cx| {
-    // Create one or more request handlers -- these are attempted in order.
-    // You can do anything you want in here, but you should eventually
-    // respond to the request with `request_cx.respond(...)`:
-    request_cx.respond(InitializeResponse {
-        protocol_version: initialize.protocol_version,
-        agent_capabilities: AgentCapabilities::default(),
-        auth_methods: Default::default(),
-        agent_info: Default::default(),
-        meta: Default::default(),
+use sacp::ClientToAgent;
+use sacp::schema::{InitializeRequest, VERSION as PROTOCOL_VERSION};
+
+ClientToAgent::builder()
+    .name("my-client")
+    .run_until(transport, async |cx| {
+        // Initialize the connection
+        cx.send_request(InitializeRequest {
+            protocol_version: PROTOCOL_VERSION,
+            client_capabilities: Default::default(),
+            client_info: Default::default(),
+            meta: None,
+        }).block_task().await?;
+
+        // Create a session and send a prompt
+        cx.build_session_cwd()?
+            .block_task()
+            .run_until(async |mut session| {
+                session.send_prompt("What is 2 + 2?")?;
+                let response = session.read_to_string().await?;
+                println!("{}", response);
+                Ok(())
+            })
+            .await
     })
-})
-.on_receive_message(async move |message: MessageAndCx<UntypedMessage, UntypedMessage>| {
-    // You can also handle any kind of message:
-    message.respond_with_error(sacp::util::internal_error("TODO"))
-})
-.serve() // Finally, start the server (or use `run_until`)
-.await
+    .await
 ```
 
-## Learning more
+## Learning More
 
-You can learn more in the [docs for `JrConnection`](https://docs.rs/symposium-acp/latest/symposium_acp/jr_connection/struct.JrConnection.html) or on our [Github Pages](https://github.com/symposium-acp/symposium-acp) site.
+See the [crate documentation](https://docs.rs/sacp) for:
 
-You may also enjoy looking at some of these examples:
+- **[Cookbook](https://docs.rs/sacp/latest/sacp/cookbook/)** - Patterns for building clients, proxies, and agents
+- **[Examples](https://github.com/symposium-dev/symposium-acp/tree/main/src/sacp/examples)** - Working code you can run
 
-- **[`simple_agent.rs`](examples/simple_agent.rs)** - Minimal agent implementation
+You may also enjoy looking at:
+
 - **[`yolo_one_shot_client.rs`](examples/yolo_one_shot_client.rs)** - Complete client that spawns an agent and sends a prompt
-- **[`elizacp`](https://crates.io/crates/elizacp)** - Full working agent with session management (also useful for testing)
-- **[`sacp-conductor`](https://crates.io/crates/sacp-conductor)** - The "conductor" is an ACP agent that composes [proxies](https://crates.io/crates/sacp-conductor) components with a final agent.
+- **[`elizacp`](https://crates.io/crates/elizacp)** - Full working agent with session management
+- **[`sacp-conductor`](https://crates.io/crates/sacp-conductor)** - Orchestrates proxy chains with a final agent
 
 ## Related Crates
 
-- **[sacp-proxy](../sacp-proxy/)** - Framework for building ACP proxies that extend agent behavior
-- **[sacp-tokio](../sacp-tokio/)** - Tokio-specific utilities (process spawning, connection management)
-- **[sacp-conductor](../sacp-conductor/)** - Binary for orchestrating proxy chains
+- **[sacp-tokio](../sacp-tokio/)** - Tokio utilities for spawning agent processes
+- **[sacp-proxy](../sacp-proxy/)** - Framework for building proxy components
+- **[sacp-conductor](../sacp-conductor/)** - Binary for running proxy chains
 
 ## License
 

--- a/src/sacp/src/session.rs
+++ b/src/sacp/src/session.rs
@@ -50,6 +50,19 @@ where
         )
     }
 
+    /// Session builder using the current working directory.
+    ///
+    /// This is a convenience wrapper around [`build_session`](Self::build_session)
+    /// that uses [`std::env::current_dir`] to get the working directory.
+    ///
+    /// Returns an error if the current directory cannot be determined.
+    pub fn build_session_cwd(&self) -> Result<SessionBuilder<Link, NullResponder>, crate::Error> {
+        let cwd = std::env::current_dir().map_err(|e| {
+            crate::Error::internal_error().with_data(format!("cannot get current directory: {e}"))
+        })?;
+        Ok(self.build_session(cwd))
+    }
+
     /// Session builder starting from an existing request.
     ///
     /// Use this when you've intercepted a `session.new` request and want to


### PR DESCRIPTION
- Reframe docs around client/proxy/agent use cases (client most common)
- Replace UntypedLink quick start with ClientToAgent using session builder
- Add build_session_cwd() convenience method for current working directory
- Add running_proxies_with_conductor cookbook section explaining conductor requirement
- Add building_an_agent cookbook section with initialization, sessions, prompts
- Update connecting_as_client to use session builder pattern
- Simplify peers section to focus on ClientPeer/AgentPeer (conductor/proxy are internal)
- Update README.md to match new structure