### PR TITLE
chore: release

### DIFF
--- a/src/elizacp/CHANGELOG.md
+++ b/src/elizacp/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [11.0.0](https://github.com/symposium-dev/symposium-acp/compare/elizacp-v10.0.0...elizacp-v11.0.0) - 2025-12-31
+
+### Added
+
+- *(elizacp)* implement Eliza algorithm based on the original style
+
 ## [10.0.0-alpha.4](https://github.com/symposium-dev/symposium-acp/compare/elizacp-v10.0.0-alpha.3...elizacp-v10.0.0-alpha.4) - 2025-12-30
 
 ### Added

--- a/src/elizacp/Cargo.toml
+++ b/src/elizacp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elizacp"
-version = "10.0.0"
+version = "11.0.0"
 edition = "2024"
 description = "Classic Eliza chatbot as an ACP agent for testing"
 license = "MIT OR Apache-2.0"
@@ -16,7 +16,7 @@ path = "src/main.rs"
 test = false
 
 [dependencies]
-sacp = { version = "10.0.0", path = "../sacp" }
+sacp = { version = "10.1.0", path = "../sacp" }
 agent-client-protocol-schema.workspace = true
 anyhow.workspace = true
 clap.workspace = true
@@ -32,7 +32,7 @@ tokio-util.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 uuid.workspace = true
-sacp-tokio = { version = "10.0.0", path = "../sacp-tokio" }
+sacp-tokio = { version = "10.1.0", path = "../sacp-tokio" }
 ratatui = "0.30.0"
 crossterm = "0.29.0"
 

--- a/src/sacp-conductor/CHANGELOG.md
+++ b/src/sacp-conductor/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [10.0.1](https://github.com/symposium-dev/symposium-acp/compare/sacp-conductor-v10.0.0...sacp-conductor-v10.0.1) - 2025-12-31
+
+### Other
+
+- Merge pull request #109 from nikomatsakis/ci-binaries
+- add binary releases for CLI tools
+
 ## [10.0.0-alpha.4](https://github.com/symposium-dev/symposium-acp/compare/sacp-conductor-v10.0.0-alpha.3...sacp-conductor-v10.0.0-alpha.4) - 2025-12-30
 
 ### Added

--- a/src/sacp-conductor/Cargo.toml
+++ b/src/sacp-conductor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-conductor"
-version = "10.0.0"
+version = "10.0.1"
 edition = "2024"
 description = "Conductor for orchestrating SACP proxy chains"
 license = "MIT OR Apache-2.0"
@@ -16,8 +16,8 @@ path = "src/main.rs"
 test-support = []
 
 [dependencies]
-sacp = { version = "10.0.0", path = "../sacp" }
-sacp-tokio = { version = "10.0.0", path = "../sacp-tokio" }
+sacp = { version = "10.1.0", path = "../sacp" }
+sacp-tokio = { version = "10.1.0", path = "../sacp-tokio" }
 sacp-trace-viewer = { version = "10.0.0", path = "../sacp-trace-viewer" }
 agent-client-protocol-schema.workspace = true
 anyhow.workspace = true

--- a/src/sacp-cookbook/CHANGELOG.md
+++ b/src/sacp-cookbook/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [10.0.1](https://github.com/symposium-dev/symposium-acp/compare/sacp-cookbook-v10.0.0...sacp-cookbook-v10.0.1) - 2025-12-31
+
+### Other
+
+- updated the following local packages: sacp, sacp-tokio, sacp-conductor, sacp-rmcp
+
 ## [10.0.0-alpha.4](https://github.com/symposium-dev/symposium-acp/compare/sacp-cookbook-v10.0.0-alpha.3...sacp-cookbook-v10.0.0-alpha.4) - 2025-12-30
 
 ### Added

--- a/src/sacp-cookbook/Cargo.toml
+++ b/src/sacp-cookbook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-cookbook"
-version = "10.0.0"
+version = "10.0.1"
 edition = "2024"
 description = "Cookbook of common patterns for building ACP components"
 license = "MIT OR Apache-2.0"
@@ -9,10 +9,10 @@ keywords = ["acp", "agent", "proxy", "mcp", "cookbook"]
 categories = ["development-tools"]
 
 [dependencies]
-sacp = { version = "10.0.0", path = "../sacp" }
-sacp-conductor = { version = "10.0.0", path = "../sacp-conductor" }
-sacp-rmcp = { version = "10.0.0", path = "../sacp-rmcp" }
-sacp-tokio = { version = "10.0.0", path = "../sacp-tokio" }
+sacp = { version = "10.1.0", path = "../sacp" }
+sacp-conductor = { version = "10.0.1", path = "../sacp-conductor" }
+sacp-rmcp = { version = "10.0.1", path = "../sacp-rmcp" }
+sacp-tokio = { version = "10.1.0", path = "../sacp-tokio" }
 
 # Re-export common dependencies needed by cookbook examples
 rmcp.workspace = true

--- a/src/sacp-rmcp/CHANGELOG.md
+++ b/src/sacp-rmcp/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [10.0.1](https://github.com/symposium-dev/symposium-acp/compare/sacp-rmcp-v10.0.0...sacp-rmcp-v10.0.1) - 2025-12-31
+
+### Other
+
+- updated the following local packages: sacp
+
 ## [10.0.0-alpha.4](https://github.com/symposium-dev/symposium-acp/compare/sacp-rmcp-v10.0.0-alpha.3...sacp-rmcp-v10.0.0-alpha.4) - 2025-12-30
 
 ### Other

--- a/src/sacp-rmcp/Cargo.toml
+++ b/src/sacp-rmcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-rmcp"
-version = "10.0.0"
+version = "10.0.1"
 edition = "2024"
 description = "rmcp integration for SACP proxy components"
 license = "MIT OR Apache-2.0"
@@ -9,7 +9,7 @@ keywords = ["acp", "agent", "proxy", "mcp", "rmcp"]
 categories = ["development-tools"]
 
 [dependencies]
-sacp = { version = "10.0.0", path = "../sacp" }
+sacp = { version = "10.1.0", path = "../sacp" }
 rmcp.workspace = true
 futures.workspace = true
 tokio.workspace = true

--- a/src/sacp-tee/CHANGELOG.md
+++ b/src/sacp-tee/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [10.0.1](https://github.com/symposium-dev/symposium-acp/compare/sacp-tee-v10.0.0...sacp-tee-v10.0.1) - 2025-12-31
+
+### Other
+
+- add binary releases for CLI tools
+
 ## [10.0.0-alpha.4](https://github.com/symposium-dev/symposium-acp/compare/sacp-tee-v10.0.0-alpha.3...sacp-tee-v10.0.0-alpha.4) - 2025-12-30
 
 ### Other

--- a/src/sacp-tee/Cargo.toml
+++ b/src/sacp-tee/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-tee"
-version = "10.0.0"
+version = "10.0.1"
 edition = "2024"
 description = "A debugging proxy that logs all ACP traffic to a file"
 license = "MIT OR Apache-2.0"
@@ -16,8 +16,8 @@ path = "src/main.rs"
 anyhow.workspace = true
 chrono.workspace = true
 clap = { workspace = true, features = ["derive"] }
-sacp = { version = "10.0.0", path = "../sacp" }
-sacp-tokio = { version = "10.0.0", path = "../sacp-tokio" }
+sacp = { version = "10.1.0", path = "../sacp" }
+sacp-tokio = { version = "10.1.0", path = "../sacp-tokio" }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 tokio = { workspace = true, features = ["full"] }

--- a/src/sacp-test/Cargo.toml
+++ b/src/sacp-test/Cargo.toml
@@ -10,9 +10,9 @@ name = "mcp-echo-server"
 path = "src/bin/mcp_echo_server.rs"
 
 [dependencies]
-sacp = { version = "10.0.0", path = "../sacp" }
-sacp-tokio = { version = "10.0.0", path = "../sacp-tokio" }
-yopo = { version = "10.0.0", path = "../yopo" }
+sacp = { version = "10.1.0", path = "../sacp" }
+sacp-tokio = { version = "10.1.0", path = "../sacp-tokio" }
+yopo = { version = "10.0.1", path = "../yopo" }
 rmcp = { workspace = true, features = ["server"] }
 schemars.workspace = true
 

--- a/src/sacp-tokio/CHANGELOG.md
+++ b/src/sacp-tokio/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [10.1.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-tokio-v10.0.0...sacp-tokio-v10.1.0) - 2025-12-31
+
+### Added
+
+- *(elizacp)* implement Eliza algorithm based on the original style
+
 ## [10.0.0-alpha.4](https://github.com/symposium-dev/symposium-acp/compare/sacp-tokio-v10.0.0-alpha.3...sacp-tokio-v10.0.0-alpha.4) - 2025-12-30
 
 ### Added

--- a/src/sacp-tokio/Cargo.toml
+++ b/src/sacp-tokio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-tokio"
-version = "10.0.0"
+version = "10.1.0"
 edition = "2024"
 description = "Tokio-based utilities for SACP (Symposium's extensions to ACP)"
 license = "MIT OR Apache-2.0"
@@ -9,7 +9,7 @@ keywords = ["acp", "agent", "protocol", "ai", "tokio"]
 categories = ["development-tools"]
 
 [dependencies]
-sacp = { version = "10.0.0", path = "../sacp" }
+sacp = { version = "10.1.0", path = "../sacp" }
 futures.workspace = true
 
 serde.workspace = true

--- a/src/sacp/CHANGELOG.md
+++ b/src/sacp/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [10.1.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-v10.0.0...sacp-v10.1.0) - 2025-12-31
+
+### Added
+
+- *(elizacp)* implement Eliza algorithm based on the original style
+
 ## [10.0.0-alpha.4](https://github.com/symposium-dev/symposium-acp/compare/sacp-v10.0.0-alpha.3...sacp-v10.0.0-alpha.4) - 2025-12-30
 
 ### Added

--- a/src/sacp/Cargo.toml
+++ b/src/sacp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp"
-version = "10.0.0"
+version = "10.1.0"
 edition = "2024"
 description = "Core protocol types and traits for SACP (Symposium's extensions to ACP)"
 license = "MIT OR Apache-2.0"

--- a/src/yopo/CHANGELOG.md
+++ b/src/yopo/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [10.0.1](https://github.com/symposium-dev/symposium-acp/compare/yopo-v10.0.0...yopo-v10.0.1) - 2025-12-31
+
+### Other
+
+- updated the following local packages: sacp, sacp-tokio
+
 ## [10.0.0-alpha.4](https://github.com/symposium-dev/symposium-acp/compare/yopo-v10.0.0-alpha.3...yopo-v10.0.0-alpha.4) - 2025-12-30
 
 ### Added

--- a/src/yopo/Cargo.toml
+++ b/src/yopo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yopo"
-version = "10.0.0"
+version = "10.0.1"
 edition = "2024"
 description = "YOPO (You Only Prompt Once) - A simple ACP client for one-shot prompts"
 license = "MIT OR Apache-2.0"
@@ -14,8 +14,8 @@ name = "yopo"
 path = "src/main.rs"
 
 [dependencies]
-sacp = { version = "10.0.0", path = "../sacp" }
-sacp-tokio = { version = "10.0.0", path = "../sacp-tokio" }
+sacp = { version = "10.1.0", path = "../sacp" }
+sacp-tokio = { version = "10.1.0", path = "../sacp-tokio" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tracing.workspace = true
 tracing-subscriber.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `sacp`: 10.0.0 -> 10.1.0 (✓ API compatible changes)
* `sacp-tokio`: 10.0.0 -> 10.1.0 (✓ API compatible changes)
* `sacp-conductor`: 10.0.0 -> 10.0.1 (✓ API compatible changes)
* `sacp-test`: 10.0.0
* `elizacp`: 10.0.0 -> 11.0.0 (⚠ API breaking changes)
* `sacp-tee`: 10.0.0 -> 10.0.1 (✓ API compatible changes)
* `yopo`: 10.0.0 -> 10.0.1
* `sacp-rmcp`: 10.0.0 -> 10.0.1
* `sacp-cookbook`: 10.0.0 -> 10.0.1

### ⚠ `elizacp` breaking changes

```text
--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/method_parameter_count_changed.ron

Failed in:
  elizacp::ElizaAgent::new now takes 1 parameters instead of 0, in /tmp/.tmpjekGuM/symposium-acp/src/elizacp/src/lib.rs:32
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `sacp`

<blockquote>

## [10.1.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-v10.0.0...sacp-v10.1.0) - 2025-12-31

### Added

- *(elizacp)* implement Eliza algorithm based on the original style
</blockquote>

## `sacp-tokio`

<blockquote>

## [10.1.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-tokio-v10.0.0...sacp-tokio-v10.1.0) - 2025-12-31

### Added

- *(elizacp)* implement Eliza algorithm based on the original style
</blockquote>

## `sacp-conductor`

<blockquote>

## [10.0.1](https://github.com/symposium-dev/symposium-acp/compare/sacp-conductor-v10.0.0...sacp-conductor-v10.0.1) - 2025-12-31

### Other

- Merge pull request #109 from nikomatsakis/ci-binaries
- add binary releases for CLI tools
</blockquote>

## `sacp-test`

<blockquote>

## [10.0.0](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-test-v10.0.0) - 2025-12-30

### Added

- *(sacp)* [**breaking**] require Send for JrMessageHandler with boxing witness macros
- [**breaking**] introduce role-based connection API
- [**breaking**] change JrMessage trait to take &self and require Clone
- *(sacp-test)* add mcp-echo-server binary for testing
- *(sacp)* add IntoHandled trait for flexible handler return types
- *(sacp-test)* add arrow proxy for testing

### Fixed

- fix cargo.toml metadata, dang it

### Other

- bump all crates to version 10.0.0
- *(sacp-test)* bump version to 10.0.0-alpha.4
- *(sacp-test)* bump version to 10.0.0-alpha.3
- release
- set version to 10.0.0-alpha.2
- release
- set all crate versions to 10.0.0-alpha.1
- release
- [**breaking**] split peer.rs into separate peer and link modules
- [**breaking**] update module and documentation references from role to peer
- [**breaking**] rename FooRole types to FooPeer
- [**breaking**] rename link endpoint types from Foo to FooRole
- [**breaking**] give component a link
- align all crate versions to 9.0.0
- release
- bump all crates to 8.0.0
- release
- bump all crates to version 7.0.0
- release
- *(sacp-test)* release v6.0.0
- set all crates to version 6.0.0
- release
- cleanup cargo metadata
- replace yolo_prompt with direct yopo::prompt calls
- *(yopo)* return sacp::Error instead of Box<dyn Error>
- *(sacp-test)* use yopo library for test client implementation
- release version 1.0.0 for all crates (sacp-rmcp at 0.8.0)
- Revert to state before 1.0.0 release
- release version 1.0.0 for all crates
- *(sacp)* add Component::serve() and simplify channel API
- [**breaking**] make Component trait ergonomic with async fn and introduce DynComponent
- [**breaking**] make Component the primary trait with Transport as blanket impl
- cleanup and simplify some of the logic to avoid "indirection" through
- unify Transport and Component traits with BoxFuture-returning signatures
- create selective jsonrpcmsg re-export module
- replace jsonrpcmsg::Message with sacp::JsonRpcMessage throughout codebase
- Merge pull request #16 from nikomatsakis/main
- fix doctests for API refactoring
- wip wip wip
- [**breaking**] remove Unpin bounds and simplify transport API
- update all versions from 1.0.0-alpha to 1.0.0-alpha.1
- release v1.0.0-alpha
- *(conductor)* add integration test with arrow proxy and eliza
- *(conductor)* add integration test with arrow proxy and eliza
- rename sacp-doc-test to sacp-test
</blockquote>

## `elizacp`

<blockquote>

## [11.0.0](https://github.com/symposium-dev/symposium-acp/compare/elizacp-v10.0.0...elizacp-v11.0.0) - 2025-12-31

### Added

- *(elizacp)* implement Eliza algorithm based on the original style
</blockquote>

## `sacp-tee`

<blockquote>

## [10.0.1](https://github.com/symposium-dev/symposium-acp/compare/sacp-tee-v10.0.0...sacp-tee-v10.0.1) - 2025-12-31

### Other

- add binary releases for CLI tools
</blockquote>

## `yopo`

<blockquote>

## [10.0.1](https://github.com/symposium-dev/symposium-acp/compare/yopo-v10.0.0...yopo-v10.0.1) - 2025-12-31

### Other

- updated the following local packages: sacp, sacp-tokio
</blockquote>

## `sacp-rmcp`

<blockquote>

## [10.0.1](https://github.com/symposium-dev/symposium-acp/compare/sacp-rmcp-v10.0.0...sacp-rmcp-v10.0.1) - 2025-12-31

### Other

- updated the following local packages: sacp
</blockquote>

## `sacp-cookbook`

<blockquote>

## [10.0.1](https://github.com/symposium-dev/symposium-acp/compare/sacp-cookbook-v10.0.0...sacp-cookbook-v10.0.1) - 2025-12-31

### Other

- updated the following local packages: sacp, sacp-tokio, sacp-conductor, sacp-rmcp
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).