### PR TITLE
chore: release

### DIFF
--- a/src/elizacp/CHANGELOG.md
+++ b/src/elizacp/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [11.0.0-alpha.2](https://github.com/symposium-dev/symposium-acp/compare/elizacp-v11.0.0-alpha.1...elizacp-v11.0.0-alpha.2) - 2026-01-19
+
+### Fixed
+
+- *(sacp)* revert accidental JrMessageHandler and JrRequestCx renames
+
+### Other
+
+- upgrade to 11.0-alpha.1
+- release
+- go back from `connect_from` to `builder`
+- *(sacp)* [**breaking**] rename *_cx variables to descriptive names
+- *(sacp)* [**breaking**] rename Serve to ConnectTo for clearer semantics
+- *(sacp)* [**breaking**] replace JrLink/JrPeer with unified Role-based API
+- *(sacp)* rename context types for clarity
+- *(sacp)* rename Jr* traits to JsonRpc* for clarity
+
 ## [12.0.0](https://github.com/symposium-dev/symposium-acp/compare/elizacp-v11.0.0...elizacp-v12.0.0) - 2026-01-19
 
 ### Fixed

--- a/src/elizacp/CHANGELOG.md
+++ b/src/elizacp/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [11.0.0-alpha.2](https://github.com/symposium-dev/symposium-acp/compare/elizacp-v11.0.0-alpha.1...elizacp-v11.0.0-alpha.2) - 2026-01-19
+## [12.0.0-alpha.1](https://github.com/symposium-dev/symposium-acp/compare/elizacp-v11.0.0-alpha.1...elizacp-v12.0.0-alpha.1) - 2026-01-19
 
 ### Fixed
 

--- a/src/elizacp/Cargo.toml
+++ b/src/elizacp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elizacp"
-version = "11.0.0-alpha.1"
+version = "11.0.0-alpha.2"
 edition = "2024"
 description = "Classic Eliza chatbot as an ACP agent for testing"
 license = "MIT OR Apache-2.0"

--- a/src/elizacp/Cargo.toml
+++ b/src/elizacp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elizacp"
-version = "11.0.0-alpha.2"
+version = "12.0.0-alpha.1"
 edition = "2024"
 description = "Classic Eliza chatbot as an ACP agent for testing"
 license = "MIT OR Apache-2.0"
@@ -16,7 +16,7 @@ path = "src/main.rs"
 test = false
 
 [dependencies]
-sacp = { version = "11.0.0-alpha.1", path = "../sacp" }
+sacp = { version = "12.0.0-alpha.1", path = "../sacp" }
 agent-client-protocol-schema.workspace = true
 anyhow.workspace = true
 clap.workspace = true
@@ -32,7 +32,7 @@ tokio-util.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 uuid.workspace = true
-sacp-tokio = { version = "11.0.0-alpha.1", path = "../sacp-tokio" }
+sacp-tokio = { version = "12.0.0-alpha.1", path = "../sacp-tokio" }
 ratatui = "0.30.0"
 crossterm = "0.29.0"
 

--- a/src/sacp-conductor/CHANGELOG.md
+++ b/src/sacp-conductor/CHANGELOG.md
@@ -7,6 +7,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [11.0.0-alpha.1](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-conductor-v11.0.0-alpha.1) - 2026-01-19
+
+### Added
+
+- *(conductor)* infer response tracing direction from context
+- *(sacp)* add Response variant to MessageCx
+
+### Fixed
+
+- *(sacp)* revert accidental JrMessageHandler and JrRequestCx renames
+- *(conductor)* normalize acp_url field in trace snapshot tests
+- *(conductor)* handle Response variants in message forwarding
+- *(conductor)* panic on Response in forwarding functions
+
+### Other
+
+- upgrade to 11.0-alpha.1
+- release
+- go back from `connect_from` to `builder`
+- fix unresolved rustdoc link warnings for v11 API
+- *(sacp)* [**breaking**] rename HandleMessageFrom to HandleDispatchFrom
+- *(sacp)* [**breaking**] rename *_cx variables to descriptive names
+- *(sacp)* [**breaking**] rename MessageCx to Dispatch for clearer semantics
+- *(sacp)* [**breaking**] rename Serve to ConnectTo for clearer semantics
+- *(sacp)* [**breaking**] replace JrLink/JrPeer with unified Role-based API
+- *(sacp)* rename JrMessageHandler to HandleMessageFrom
+- *(sacp)* rename JrConnectionBuilder to ConnectFrom
+- *(sacp)* simplify spawn_connection API
+- *(sacp)* rename context types for clarity
+- *(sacp)* rename JrResponder ecosystem to Run
+- *(sacp)* rename Jr* traits to JsonRpc* for clarity
+- get tracing working
+- refactor tracing
+- *(conductor)* simplify trace bridge API
+- *(conductor)* move tracing to transport layer with bridge wrappers
+- remove into_connection_builder
+- add a test that shows a request going all the way back to the client
+- *(sacp-conductor)* add trace snapshot for client-hosted MCP server
+- *(sacp-conductor)* add trace snapshot test for agent-initiated MCP tool calls
+- wip
+- *(sacp)* introduce JrResponseCx for incoming response handling
+
 ## [11.0.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-conductor-v10.0.1...sacp-conductor-v11.0.0) - 2026-01-19
 
 ### Added

--- a/src/sacp-conductor/CHANGELOG.md
+++ b/src/sacp-conductor/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [11.0.0-alpha.1](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-conductor-v11.0.0-alpha.1) - 2026-01-19
+## [12.0.0-alpha.1](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-conductor-v12.0.0-alpha.1) - 2026-01-19
 
 ### Added
 

--- a/src/sacp-conductor/Cargo.toml
+++ b/src/sacp-conductor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-conductor"
-version = "11.0.0-alpha.1"
+version = "12.0.0-alpha.1"
 edition = "2024"
 description = "Conductor for orchestrating SACP proxy chains"
 license = "MIT OR Apache-2.0"
@@ -16,9 +16,9 @@ path = "src/main.rs"
 test-support = []
 
 [dependencies]
-sacp = { version = "11.0.0-alpha.1", path = "../sacp" }
-sacp-tokio = { version = "11.0.0-alpha.1", path = "../sacp-tokio" }
-sacp-trace-viewer = { version = "11.0.0-alpha.1", path = "../sacp-trace-viewer" }
+sacp = { version = "12.0.0-alpha.1", path = "../sacp" }
+sacp-tokio = { version = "12.0.0-alpha.1", path = "../sacp-tokio" }
+sacp-trace-viewer = { version = "12.0.0-alpha.1", path = "../sacp-trace-viewer" }
 agent-client-protocol-schema.workspace = true
 anyhow.workspace = true
 axum.workspace = true

--- a/src/sacp-cookbook/CHANGELOG.md
+++ b/src/sacp-cookbook/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [11.0.0-alpha.1](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-cookbook-v11.0.0-alpha.1) - 2026-01-19
+
+### Other
+
+- upgrade to 11.0-alpha.1
+- release
+- go back from `connect_from` to `builder`
+- fix unresolved rustdoc link warnings for v11 API
+- *(sacp-cookbook)* update cookbook examples for v11 Role-based API
+- *(sacp)* [**breaking**] rename HandleMessageFrom to HandleDispatchFrom
+- *(sacp)* [**breaking**] rename *_cx variables to descriptive names
+- *(sacp)* [**breaking**] rename MessageCx to Dispatch for clearer semantics
+- *(sacp)* [**breaking**] rename Serve to ConnectTo for clearer semantics
+- *(sacp)* [**breaking**] replace JrLink/JrPeer with unified Role-based API
+- *(sacp)* rename JrMessageHandler to HandleMessageFrom
+- *(sacp)* rename JrConnectionBuilder to ConnectFrom
+- *(sacp)* simplify spawn_connection API
+- *(sacp)* rename context types for clarity
+- *(sacp)* rename JrResponder ecosystem to Run
+
 ## [11.0.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-cookbook-v10.0.1...sacp-cookbook-v11.0.0) - 2026-01-19
 
 ### Other

--- a/src/sacp-cookbook/CHANGELOG.md
+++ b/src/sacp-cookbook/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [11.0.0-alpha.1](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-cookbook-v11.0.0-alpha.1) - 2026-01-19
+## [12.0.0-alpha.1](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-cookbook-v12.0.0-alpha.1) - 2026-01-19
 
 ### Other
 

--- a/src/sacp-cookbook/Cargo.toml
+++ b/src/sacp-cookbook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-cookbook"
-version = "11.0.0-alpha.1"
+version = "12.0.0-alpha.1"
 edition = "2024"
 description = "Cookbook of common patterns for building ACP components"
 license = "MIT OR Apache-2.0"
@@ -9,10 +9,10 @@ keywords = ["acp", "agent", "proxy", "mcp", "cookbook"]
 categories = ["development-tools"]
 
 [dependencies]
-sacp = { version = "11.0.0-alpha.1", path = "../sacp" }
-sacp-conductor = { version = "11.0.0-alpha.1", path = "../sacp-conductor" }
-sacp-rmcp = { version = "11.0.0-alpha.1", path = "../sacp-rmcp" }
-sacp-tokio = { version = "11.0.0-alpha.1", path = "../sacp-tokio" }
+sacp = { version = "12.0.0-alpha.1", path = "../sacp" }
+sacp-conductor = { version = "12.0.0-alpha.1", path = "../sacp-conductor" }
+sacp-rmcp = { version = "12.0.0-alpha.1", path = "../sacp-rmcp" }
+sacp-tokio = { version = "12.0.0-alpha.1", path = "../sacp-tokio" }
 
 # Re-export common dependencies needed by cookbook examples
 rmcp.workspace = true

--- a/src/sacp-derive/CHANGELOG.md
+++ b/src/sacp-derive/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [11.0.0-alpha.1](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-derive-v11.0.0-alpha.1) - 2026-01-19
+
+### Added
+
+- *(sacp)* add matches_method to JrMessage, change parse_message to return Result
+
+### Other
+
+- upgrade to 11.0-alpha.1
+- release
+- *(sacp)* rename Jr* traits to JsonRpc* for clarity
+
 ## [10.1.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-derive-v10.0.0...sacp-derive-v10.1.0) - 2026-01-19
 
 ### Added

--- a/src/sacp-derive/CHANGELOG.md
+++ b/src/sacp-derive/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [11.0.0-alpha.1](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-derive-v11.0.0-alpha.1) - 2026-01-19
+## [12.0.0-alpha.1](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-derive-v12.0.0-alpha.1) - 2026-01-19
 
 ### Added
 

--- a/src/sacp-derive/Cargo.toml
+++ b/src/sacp-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-derive"
-version = "11.0.0-alpha.1"
+version = "12.0.0-alpha.1"
 edition = "2024"
 description = "Derive macros for SACP JSON-RPC traits"
 license = "MIT OR Apache-2.0"

--- a/src/sacp-rmcp/CHANGELOG.md
+++ b/src/sacp-rmcp/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [11.0.0-alpha.1](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-rmcp-v11.0.0-alpha.1) - 2026-01-19
+
+### Other
+
+- upgrade to 11.0-alpha.1
+- release
+- go back from `connect_from` to `builder`
+- fix unresolved rustdoc link warnings for v11 API
+- *(sacp)* [**breaking**] rename Serve to ConnectTo for clearer semantics
+- *(sacp)* [**breaking**] replace JrLink/JrPeer with unified Role-based API
+- *(sacp)* rename JrResponder ecosystem to Run
+
 ## [11.0.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-rmcp-v10.0.1...sacp-rmcp-v11.0.0) - 2026-01-19
 
 ### Other

--- a/src/sacp-rmcp/CHANGELOG.md
+++ b/src/sacp-rmcp/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [11.0.0-alpha.1](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-rmcp-v11.0.0-alpha.1) - 2026-01-19
+## [12.0.0-alpha.1](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-rmcp-v12.0.0-alpha.1) - 2026-01-19
 
 ### Other
 

--- a/src/sacp-rmcp/Cargo.toml
+++ b/src/sacp-rmcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-rmcp"
-version = "11.0.0-alpha.1"
+version = "12.0.0-alpha.1"
 edition = "2024"
 description = "rmcp integration for SACP proxy components"
 license = "MIT OR Apache-2.0"
@@ -9,7 +9,7 @@ keywords = ["acp", "agent", "proxy", "mcp", "rmcp"]
 categories = ["development-tools"]
 
 [dependencies]
-sacp = { version = "11.0.0-alpha.1", path = "../sacp" }
+sacp = { version = "12.0.0-alpha.1", path = "../sacp" }
 rmcp.workspace = true
 futures.workspace = true
 tokio.workspace = true

--- a/src/sacp-test/CHANGELOG.md
+++ b/src/sacp-test/CHANGELOG.md
@@ -7,6 +7,81 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [11.0.0-alpha.1](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-test-v11.0.0-alpha.1) - 2026-01-19
+
+### Added
+
+- *(sacp)* add matches_method to JrMessage, change parse_message to return Result
+- *(elizacp)* implement Eliza algorithm based on the original style
+- *(sacp)* [**breaking**] require Send for JrMessageHandler with boxing witness macros
+- [**breaking**] introduce role-based connection API
+- [**breaking**] change JrMessage trait to take &self and require Clone
+- *(sacp-test)* add mcp-echo-server binary for testing
+- *(sacp)* add IntoHandled trait for flexible handler return types
+- *(sacp-test)* add arrow proxy for testing
+
+### Fixed
+
+- fix cargo.toml metadata, dang it
+
+### Other
+
+- upgrade to 11.0-alpha.1
+- release
+- go back from `connect_from` to `builder`
+- *(sacp)* [**breaking**] rename Serve to ConnectTo for clearer semantics
+- *(sacp)* [**breaking**] replace JrLink/JrPeer with unified Role-based API
+- *(sacp)* rename JrConnectionBuilder to ConnectFrom
+- *(sacp)* rename Jr* traits to JsonRpc* for clarity
+- wip
+- release
+- *(sacp-test)* release v10.0.0
+- bump all crates to version 10.0.0
+- *(sacp-test)* bump version to 10.0.0-alpha.4
+- *(sacp-test)* bump version to 10.0.0-alpha.3
+- release
+- set version to 10.0.0-alpha.2
+- release
+- set all crate versions to 10.0.0-alpha.1
+- release
+- [**breaking**] split peer.rs into separate peer and link modules
+- [**breaking**] update module and documentation references from role to peer
+- [**breaking**] rename FooRole types to FooPeer
+- [**breaking**] rename link endpoint types from Foo to FooRole
+- [**breaking**] give component a link
+- align all crate versions to 9.0.0
+- release
+- bump all crates to 8.0.0
+- release
+- bump all crates to version 7.0.0
+- release
+- *(sacp-test)* release v6.0.0
+- set all crates to version 6.0.0
+- release
+- cleanup cargo metadata
+- replace yolo_prompt with direct yopo::prompt calls
+- *(yopo)* return sacp::Error instead of Box<dyn Error>
+- *(sacp-test)* use yopo library for test client implementation
+- release version 1.0.0 for all crates (sacp-rmcp at 0.8.0)
+- Revert to state before 1.0.0 release
+- release version 1.0.0 for all crates
+- *(sacp)* add Component::serve() and simplify channel API
+- [**breaking**] make Component trait ergonomic with async fn and introduce DynComponent
+- [**breaking**] make Component the primary trait with Transport as blanket impl
+- cleanup and simplify some of the logic to avoid "indirection" through
+- unify Transport and Component traits with BoxFuture-returning signatures
+- create selective jsonrpcmsg re-export module
+- replace jsonrpcmsg::Message with sacp::JsonRpcMessage throughout codebase
+- Merge pull request #16 from nikomatsakis/main
+- fix doctests for API refactoring
+- wip wip wip
+- [**breaking**] remove Unpin bounds and simplify transport API
+- update all versions from 1.0.0-alpha to 1.0.0-alpha.1
+- release v1.0.0-alpha
+- *(conductor)* add integration test with arrow proxy and eliza
+- *(conductor)* add integration test with arrow proxy and eliza
+- rename sacp-doc-test to sacp-test
+
 ## [10.0.0](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-test-v10.0.0) - 2025-12-30
 
 ### Added

--- a/src/sacp-test/CHANGELOG.md
+++ b/src/sacp-test/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [11.0.0-alpha.1](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-test-v11.0.0-alpha.1) - 2026-01-19
+## [12.0.0-alpha.1](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-test-v12.0.0-alpha.1) - 2026-01-19
 
 ### Added
 

--- a/src/sacp-test/Cargo.toml
+++ b/src/sacp-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-test"
-version = "11.0.0-alpha.1"
+version = "12.0.0-alpha.1"
 edition = "2024"
 description = "Test utilities and mock implementations for SACP"
 license = "MIT OR Apache-2.0"
@@ -10,9 +10,9 @@ name = "mcp-echo-server"
 path = "src/bin/mcp_echo_server.rs"
 
 [dependencies]
-sacp = { version = "11.0.0-alpha.1", path = "../sacp" }
-sacp-tokio = { version = "11.0.0-alpha.1", path = "../sacp-tokio" }
-yopo = { version = "11.0.0-alpha.1", path = "../yopo" }
+sacp = { version = "12.0.0-alpha.1", path = "../sacp" }
+sacp-tokio = { version = "12.0.0-alpha.1", path = "../sacp-tokio" }
+yopo = { version = "12.0.0-alpha.1", path = "../yopo" }
 rmcp = { workspace = true, features = ["server"] }
 schemars.workspace = true
 

--- a/src/sacp-tokio/CHANGELOG.md
+++ b/src/sacp-tokio/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [11.0.0-alpha.1](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-tokio-v11.0.0-alpha.1) - 2026-01-19
+
+### Other
+
+- upgrade to 11.0-alpha.1
+- release
+- go back from `connect_from` to `builder`
+- fix unresolved rustdoc link warnings for v11 API
+- *(sacp)* [**breaking**] rename *_cx variables to descriptive names
+- *(sacp)* [**breaking**] rename MessageCx to Dispatch for clearer semantics
+- *(sacp)* [**breaking**] rename Serve to ConnectTo for clearer semantics
+- *(sacp)* [**breaking**] replace JrLink/JrPeer with unified Role-based API
+- *(sacp)* rename JrConnectionBuilder to ConnectFrom
+- *(sacp)* rename Jr* traits to JsonRpc* for clarity
+
 ## [11.0.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-tokio-v10.1.0...sacp-tokio-v11.0.0) - 2026-01-19
 
 ### Other

--- a/src/sacp-tokio/CHANGELOG.md
+++ b/src/sacp-tokio/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [11.0.0-alpha.1](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-tokio-v11.0.0-alpha.1) - 2026-01-19
+## [12.0.0-alpha.1](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-tokio-v12.0.0-alpha.1) - 2026-01-19
 
 ### Other
 

--- a/src/sacp-tokio/Cargo.toml
+++ b/src/sacp-tokio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-tokio"
-version = "11.0.0-alpha.1"
+version = "12.0.0-alpha.1"
 edition = "2024"
 description = "Tokio-based utilities for SACP (Symposium's extensions to ACP)"
 license = "MIT OR Apache-2.0"
@@ -9,7 +9,7 @@ keywords = ["acp", "agent", "protocol", "ai", "tokio"]
 categories = ["development-tools"]
 
 [dependencies]
-sacp = { version = "11.0.0-alpha.1", path = "../sacp" }
+sacp = { version = "12.0.0-alpha.1", path = "../sacp" }
 futures.workspace = true
 
 serde.workspace = true

--- a/src/sacp-trace-viewer/CHANGELOG.md
+++ b/src/sacp-trace-viewer/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [11.0.0-alpha.1](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-trace-viewer-v11.0.0-alpha.1) - 2026-01-19
+
+### Other
+
+- upgrade to 11.0-alpha.1
+
 ## [6.0.0] - 2025-12-15
 
 ### Other

--- a/src/sacp-trace-viewer/CHANGELOG.md
+++ b/src/sacp-trace-viewer/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [11.0.0-alpha.1](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-trace-viewer-v11.0.0-alpha.1) - 2026-01-19
+## [12.0.0-alpha.1](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-trace-viewer-v12.0.0-alpha.1) - 2026-01-19
 
 ### Other
 

--- a/src/sacp-trace-viewer/Cargo.toml
+++ b/src/sacp-trace-viewer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp-trace-viewer"
-version = "11.0.0-alpha.1"
+version = "12.0.0-alpha.1"
 edition = "2024"
 description = "Interactive sequence diagram viewer for SACP trace files"
 license = "MIT OR Apache-2.0"

--- a/src/sacp/CHANGELOG.md
+++ b/src/sacp/CHANGELOG.md
@@ -7,6 +7,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [11.0.0-alpha.1](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-v11.0.0-alpha.1) - 2026-01-19
+
+### Added
+
+- *(sacp)* introduce Role trait system
+- *(sacp)* expose outgoing request id on JrResponse
+- *(sacp)* parse responses in into_typed_message_cx
+- *(sacp)* add matches_method to JrMessage, change parse_message to return Result
+- *(sacp)* add if_response_to and if_ok_response_to to MatchMessageFrom
+- *(sacp)* add if_response_to and if_ok_response_to to MatchMessage
+- *(sacp)* route responses through handler chain
+- *(sacp)* store method name with pending reply subscriptions
+- *(sacp)* add Response variant to MessageCx
+
+### Fixed
+
+- *(sacp)* revert accidental JrMessageHandler and JrRequestCx renames
+- *(conductor)* handle Response variants in message forwarding
+
+### Other
+
+- upgrade to 11.0-alpha.1
+- release
+- go back from `connect_from` to `builder`
+- fix unresolved rustdoc link warnings for v11 API
+- *(sacp)* [**breaking**] rename HandleMessageFrom to HandleDispatchFrom
+- *(sacp)* [**breaking**] rename *_cx variables to descriptive names
+- *(sacp)* [**breaking**] rename MessageCx to Dispatch for clearer semantics
+- *(sacp)* update doctests for new Role-based API
+- *(sacp)* [**breaking**] rename Serve to ConnectTo for clearer semantics
+- *(sacp)* [**breaking**] replace JrLink/JrPeer with unified Role-based API
+- *(sacp)* rename JrMessageHandler to HandleMessageFrom
+- *(sacp)* rename JrConnectionBuilder to ConnectFrom
+- *(sacp)* simplify spawn_connection API
+- *(sacp)* rename context types for clarity
+- *(sacp)* rename JrResponder ecosystem to Run
+- *(sacp)* rename Jr* traits to JsonRpc* for clarity
+- wip
+- wip
+- *(sacp)* use handle_incoming_message for response peer filtering
+- *(sacp)* introduce JrResponseCx for incoming response handling
+- *(sacp)* unify JrRequestCx send logic into send_fn
+
 ## [11.0.0](https://github.com/symposium-dev/symposium-acp/compare/sacp-v10.1.0...sacp-v11.0.0) - 2026-01-19
 
 ### Added

--- a/src/sacp/CHANGELOG.md
+++ b/src/sacp/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [11.0.0-alpha.1](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-v11.0.0-alpha.1) - 2026-01-19
+## [12.0.0-alpha.1](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-v12.0.0-alpha.1) - 2026-01-19
 
 ### Added
 

--- a/src/sacp/Cargo.toml
+++ b/src/sacp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sacp"
-version = "11.0.0-alpha.1"
+version = "12.0.0-alpha.1"
 edition = "2024"
 description = "Core protocol types and traits for SACP (Symposium's extensions to ACP)"
 license = "MIT OR Apache-2.0"
@@ -10,7 +10,7 @@ categories = ["development-tools"]
 
 [dependencies]
 agent-client-protocol-schema.workspace = true
-sacp-derive = { version = "11.0.0-alpha.1", path = "../sacp-derive" }
+sacp-derive = { version = "12.0.0-alpha.1", path = "../sacp-derive" }
 anyhow.workspace = true
 boxfnonce.workspace = true
 futures.workspace = true

--- a/src/yopo/CHANGELOG.md
+++ b/src/yopo/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [11.0.0-alpha.1](https://github.com/symposium-dev/symposium-acp/releases/tag/yopo-v11.0.0-alpha.1) - 2026-01-19
+
+### Other
+
+- upgrade to 11.0-alpha.1
+- release
+- go back from `connect_from` to `builder`
+- *(sacp)* [**breaking**] rename *_cx variables to descriptive names
+- *(sacp)* [**breaking**] rename MessageCx to Dispatch for clearer semantics
+- *(sacp)* [**breaking**] rename Serve to ConnectTo for clearer semantics
+- *(sacp)* [**breaking**] replace JrLink/JrPeer with unified Role-based API
+- *(sacp)* rename context types for clarity
+
 ## [11.0.0](https://github.com/symposium-dev/symposium-acp/compare/yopo-v10.0.1...yopo-v11.0.0) - 2026-01-19
 
 ### Other

--- a/src/yopo/CHANGELOG.md
+++ b/src/yopo/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [11.0.0-alpha.1](https://github.com/symposium-dev/symposium-acp/releases/tag/yopo-v11.0.0-alpha.1) - 2026-01-19
+## [12.0.0-alpha.1](https://github.com/symposium-dev/symposium-acp/releases/tag/yopo-v12.0.0-alpha.1) - 2026-01-19
 
 ### Other
 

--- a/src/yopo/Cargo.toml
+++ b/src/yopo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yopo"
-version = "11.0.0-alpha.1"
+version = "12.0.0-alpha.1"
 edition = "2024"
 description = "YOPO (You Only Prompt Once) - A simple ACP client for one-shot prompts"
 license = "MIT OR Apache-2.0"
@@ -14,8 +14,8 @@ name = "yopo"
 path = "src/main.rs"
 
 [dependencies]
-sacp = { version = "11.0.0-alpha.1", path = "../sacp" }
-sacp-tokio = { version = "11.0.0-alpha.1", path = "../sacp-tokio" }
+sacp = { version = "12.0.0-alpha.1", path = "../sacp" }
+sacp-tokio = { version = "12.0.0-alpha.1", path = "../sacp-tokio" }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tracing.workspace = true
 tracing-subscriber.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `sacp-derive`: 11.0.0-alpha.1
* `sacp`: 11.0.0-alpha.1
* `sacp-tokio`: 11.0.0-alpha.1
* `sacp-trace-viewer`: 11.0.0-alpha.1
* `sacp-conductor`: 11.0.0-alpha.1
* `yopo`: 11.0.0-alpha.1
* `sacp-test`: 11.0.0-alpha.1
* `elizacp`: 11.0.0-alpha.1 -> 11.0.0-alpha.2 (✓ API compatible changes)
* `sacp-rmcp`: 11.0.0-alpha.1
* `sacp-cookbook`: 11.0.0-alpha.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `sacp-derive`

<blockquote>

## [11.0.0-alpha.1](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-derive-v11.0.0-alpha.1) - 2026-01-19

### Added

- *(sacp)* add matches_method to JrMessage, change parse_message to return Result

### Other

- upgrade to 11.0-alpha.1
- release
- *(sacp)* rename Jr* traits to JsonRpc* for clarity
</blockquote>

## `sacp`

<blockquote>

## [11.0.0-alpha.1](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-v11.0.0-alpha.1) - 2026-01-19

### Added

- *(sacp)* introduce Role trait system
- *(sacp)* expose outgoing request id on JrResponse
- *(sacp)* parse responses in into_typed_message_cx
- *(sacp)* add matches_method to JrMessage, change parse_message to return Result
- *(sacp)* add if_response_to and if_ok_response_to to MatchMessageFrom
- *(sacp)* add if_response_to and if_ok_response_to to MatchMessage
- *(sacp)* route responses through handler chain
- *(sacp)* store method name with pending reply subscriptions
- *(sacp)* add Response variant to MessageCx

### Fixed

- *(sacp)* revert accidental JrMessageHandler and JrRequestCx renames
- *(conductor)* handle Response variants in message forwarding

### Other

- upgrade to 11.0-alpha.1
- release
- go back from `connect_from` to `builder`
- fix unresolved rustdoc link warnings for v11 API
- *(sacp)* [**breaking**] rename HandleMessageFrom to HandleDispatchFrom
- *(sacp)* [**breaking**] rename *_cx variables to descriptive names
- *(sacp)* [**breaking**] rename MessageCx to Dispatch for clearer semantics
- *(sacp)* update doctests for new Role-based API
- *(sacp)* [**breaking**] rename Serve to ConnectTo for clearer semantics
- *(sacp)* [**breaking**] replace JrLink/JrPeer with unified Role-based API
- *(sacp)* rename JrMessageHandler to HandleMessageFrom
- *(sacp)* rename JrConnectionBuilder to ConnectFrom
- *(sacp)* simplify spawn_connection API
- *(sacp)* rename context types for clarity
- *(sacp)* rename JrResponder ecosystem to Run
- *(sacp)* rename Jr* traits to JsonRpc* for clarity
- wip
- wip
- *(sacp)* use handle_incoming_message for response peer filtering
- *(sacp)* introduce JrResponseCx for incoming response handling
- *(sacp)* unify JrRequestCx send logic into send_fn
</blockquote>

## `sacp-tokio`

<blockquote>

## [11.0.0-alpha.1](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-tokio-v11.0.0-alpha.1) - 2026-01-19

### Other

- upgrade to 11.0-alpha.1
- release
- go back from `connect_from` to `builder`
- fix unresolved rustdoc link warnings for v11 API
- *(sacp)* [**breaking**] rename *_cx variables to descriptive names
- *(sacp)* [**breaking**] rename MessageCx to Dispatch for clearer semantics
- *(sacp)* [**breaking**] rename Serve to ConnectTo for clearer semantics
- *(sacp)* [**breaking**] replace JrLink/JrPeer with unified Role-based API
- *(sacp)* rename JrConnectionBuilder to ConnectFrom
- *(sacp)* rename Jr* traits to JsonRpc* for clarity
</blockquote>

## `sacp-trace-viewer`

<blockquote>

## [11.0.0-alpha.1](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-trace-viewer-v11.0.0-alpha.1) - 2026-01-19

### Other

- upgrade to 11.0-alpha.1
</blockquote>

## `sacp-conductor`

<blockquote>

## [11.0.0-alpha.1](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-conductor-v11.0.0-alpha.1) - 2026-01-19

### Added

- *(conductor)* infer response tracing direction from context
- *(sacp)* add Response variant to MessageCx

### Fixed

- *(sacp)* revert accidental JrMessageHandler and JrRequestCx renames
- *(conductor)* normalize acp_url field in trace snapshot tests
- *(conductor)* handle Response variants in message forwarding
- *(conductor)* panic on Response in forwarding functions

### Other

- upgrade to 11.0-alpha.1
- release
- go back from `connect_from` to `builder`
- fix unresolved rustdoc link warnings for v11 API
- *(sacp)* [**breaking**] rename HandleMessageFrom to HandleDispatchFrom
- *(sacp)* [**breaking**] rename *_cx variables to descriptive names
- *(sacp)* [**breaking**] rename MessageCx to Dispatch for clearer semantics
- *(sacp)* [**breaking**] rename Serve to ConnectTo for clearer semantics
- *(sacp)* [**breaking**] replace JrLink/JrPeer with unified Role-based API
- *(sacp)* rename JrMessageHandler to HandleMessageFrom
- *(sacp)* rename JrConnectionBuilder to ConnectFrom
- *(sacp)* simplify spawn_connection API
- *(sacp)* rename context types for clarity
- *(sacp)* rename JrResponder ecosystem to Run
- *(sacp)* rename Jr* traits to JsonRpc* for clarity
- get tracing working
- refactor tracing
- *(conductor)* simplify trace bridge API
- *(conductor)* move tracing to transport layer with bridge wrappers
- remove into_connection_builder
- add a test that shows a request going all the way back to the client
- *(sacp-conductor)* add trace snapshot for client-hosted MCP server
- *(sacp-conductor)* add trace snapshot test for agent-initiated MCP tool calls
- wip
- *(sacp)* introduce JrResponseCx for incoming response handling
</blockquote>

## `yopo`

<blockquote>

## [11.0.0-alpha.1](https://github.com/symposium-dev/symposium-acp/releases/tag/yopo-v11.0.0-alpha.1) - 2026-01-19

### Other

- upgrade to 11.0-alpha.1
- release
- go back from `connect_from` to `builder`
- *(sacp)* [**breaking**] rename *_cx variables to descriptive names
- *(sacp)* [**breaking**] rename MessageCx to Dispatch for clearer semantics
- *(sacp)* [**breaking**] rename Serve to ConnectTo for clearer semantics
- *(sacp)* [**breaking**] replace JrLink/JrPeer with unified Role-based API
- *(sacp)* rename context types for clarity
</blockquote>

## `sacp-test`

<blockquote>

## [11.0.0-alpha.1](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-test-v11.0.0-alpha.1) - 2026-01-19

### Added

- *(sacp)* add matches_method to JrMessage, change parse_message to return Result
- *(elizacp)* implement Eliza algorithm based on the original style
- *(sacp)* [**breaking**] require Send for JrMessageHandler with boxing witness macros
- [**breaking**] introduce role-based connection API
- [**breaking**] change JrMessage trait to take &self and require Clone
- *(sacp-test)* add mcp-echo-server binary for testing
- *(sacp)* add IntoHandled trait for flexible handler return types
- *(sacp-test)* add arrow proxy for testing

### Fixed

- fix cargo.toml metadata, dang it

### Other

- upgrade to 11.0-alpha.1
- release
- go back from `connect_from` to `builder`
- *(sacp)* [**breaking**] rename Serve to ConnectTo for clearer semantics
- *(sacp)* [**breaking**] replace JrLink/JrPeer with unified Role-based API
- *(sacp)* rename JrConnectionBuilder to ConnectFrom
- *(sacp)* rename Jr* traits to JsonRpc* for clarity
- wip
- release
- *(sacp-test)* release v10.0.0
- bump all crates to version 10.0.0
- *(sacp-test)* bump version to 10.0.0-alpha.4
- *(sacp-test)* bump version to 10.0.0-alpha.3
- release
- set version to 10.0.0-alpha.2
- release
- set all crate versions to 10.0.0-alpha.1
- release
- [**breaking**] split peer.rs into separate peer and link modules
- [**breaking**] update module and documentation references from role to peer
- [**breaking**] rename FooRole types to FooPeer
- [**breaking**] rename link endpoint types from Foo to FooRole
- [**breaking**] give component a link
- align all crate versions to 9.0.0
- release
- bump all crates to 8.0.0
- release
- bump all crates to version 7.0.0
- release
- *(sacp-test)* release v6.0.0
- set all crates to version 6.0.0
- release
- cleanup cargo metadata
- replace yolo_prompt with direct yopo::prompt calls
- *(yopo)* return sacp::Error instead of Box<dyn Error>
- *(sacp-test)* use yopo library for test client implementation
- release version 1.0.0 for all crates (sacp-rmcp at 0.8.0)
- Revert to state before 1.0.0 release
- release version 1.0.0 for all crates
- *(sacp)* add Component::serve() and simplify channel API
- [**breaking**] make Component trait ergonomic with async fn and introduce DynComponent
- [**breaking**] make Component the primary trait with Transport as blanket impl
- cleanup and simplify some of the logic to avoid "indirection" through
- unify Transport and Component traits with BoxFuture-returning signatures
- create selective jsonrpcmsg re-export module
- replace jsonrpcmsg::Message with sacp::JsonRpcMessage throughout codebase
- Merge pull request #16 from nikomatsakis/main
- fix doctests for API refactoring
- wip wip wip
- [**breaking**] remove Unpin bounds and simplify transport API
- update all versions from 1.0.0-alpha to 1.0.0-alpha.1
- release v1.0.0-alpha
- *(conductor)* add integration test with arrow proxy and eliza
- *(conductor)* add integration test with arrow proxy and eliza
- rename sacp-doc-test to sacp-test
</blockquote>

## `elizacp`

<blockquote>

## [11.0.0-alpha.2](https://github.com/symposium-dev/symposium-acp/compare/elizacp-v11.0.0-alpha.1...elizacp-v11.0.0-alpha.2) - 2026-01-19

### Fixed

- *(sacp)* revert accidental JrMessageHandler and JrRequestCx renames

### Other

- upgrade to 11.0-alpha.1
- release
- go back from `connect_from` to `builder`
- *(sacp)* [**breaking**] rename *_cx variables to descriptive names
- *(sacp)* [**breaking**] rename Serve to ConnectTo for clearer semantics
- *(sacp)* [**breaking**] replace JrLink/JrPeer with unified Role-based API
- *(sacp)* rename context types for clarity
- *(sacp)* rename Jr* traits to JsonRpc* for clarity
</blockquote>

## `sacp-rmcp`

<blockquote>

## [11.0.0-alpha.1](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-rmcp-v11.0.0-alpha.1) - 2026-01-19

### Other

- upgrade to 11.0-alpha.1
- release
- go back from `connect_from` to `builder`
- fix unresolved rustdoc link warnings for v11 API
- *(sacp)* [**breaking**] rename Serve to ConnectTo for clearer semantics
- *(sacp)* [**breaking**] replace JrLink/JrPeer with unified Role-based API
- *(sacp)* rename JrResponder ecosystem to Run
</blockquote>

## `sacp-cookbook`

<blockquote>

## [11.0.0-alpha.1](https://github.com/symposium-dev/symposium-acp/releases/tag/sacp-cookbook-v11.0.0-alpha.1) - 2026-01-19

### Other

- upgrade to 11.0-alpha.1
- release
- go back from `connect_from` to `builder`
- fix unresolved rustdoc link warnings for v11 API
- *(sacp-cookbook)* update cookbook examples for v11 Role-based API
- *(sacp)* [**breaking**] rename HandleMessageFrom to HandleDispatchFrom
- *(sacp)* [**breaking**] rename *_cx variables to descriptive names
- *(sacp)* [**breaking**] rename MessageCx to Dispatch for clearer semantics
- *(sacp)* [**breaking**] rename Serve to ConnectTo for clearer semantics
- *(sacp)* [**breaking**] replace JrLink/JrPeer with unified Role-based API
- *(sacp)* rename JrMessageHandler to HandleMessageFrom
- *(sacp)* rename JrConnectionBuilder to ConnectFrom
- *(sacp)* simplify spawn_connection API
- *(sacp)* rename context types for clarity
- *(sacp)* rename JrResponder ecosystem to Run
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).