### PR TITLE
refactor: consolidate JsonRpc trait implementations with macros

### DIFF
--- a/src/sacp/Cargo.toml
+++ b/src/sacp/Cargo.toml
@@ -8,6 +8,22 @@ repository = "https://github.com/symposium-dev/symposium-acp"
 keywords = ["acp", "agent", "protocol", "ai"]
 categories = ["development-tools"]
 
+[features]
+default = []
+
+# Forward unstable features from agent-client-protocol-schema.
+# Enable these to get support for the corresponding unstable ACP methods.
+unstable = [
+    "unstable_session_model",
+    "unstable_session_fork",
+    "unstable_session_resume",
+    "unstable_session_close",
+]
+unstable_session_model = ["agent-client-protocol-schema/unstable_session_model"]
+unstable_session_fork = ["agent-client-protocol-schema/unstable_session_fork"]
+unstable_session_resume = ["agent-client-protocol-schema/unstable_session_resume"]
+unstable_session_close = ["agent-client-protocol-schema/unstable_session_close"]
+
 [dependencies]
 agent-client-protocol-schema.workspace = true
 sacp-derive = { version = "11.0.0", path = "../sacp-derive" }

--- a/src/sacp/src/schema/agent_to_client/notifications.rs
+++ b/src/sacp/src/schema/agent_to_client/notifications.rs
@@ -1,32 +1,3 @@
 use crate::schema::SessionNotification;
-use serde::Serialize;
 
-use crate::jsonrpc::{JsonRpcMessage, JsonRpcNotification};
-
-const METHOD_SESSION_UPDATE: &str = "session/update";
-
-// Agent -> Client notifications
-// These are one-way messages that agents send to clients/editors
-
-impl JsonRpcMessage for SessionNotification {
-    fn matches_method(method: &str) -> bool {
-        method == METHOD_SESSION_UPDATE
-    }
-
-    fn method(&self) -> &str {
-        METHOD_SESSION_UPDATE
-    }
-
-    fn to_untyped_message(&self) -> Result<crate::UntypedMessage, crate::Error> {
-        crate::UntypedMessage::new(self.method(), self)
-    }
-
-    fn parse_message(method: &str, params: &impl Serialize) -> Result<Self, crate::Error> {
-        if !Self::matches_method(method) {
-            return Err(crate::Error::method_not_found());
-        }
-        crate::util::json_cast(params)
-    }
-}
-
-impl JsonRpcNotification for SessionNotification {}
+impl_jsonrpc_notification!(SessionNotification, "session/update");

--- a/src/sacp/src/schema/agent_to_client/requests.rs
+++ b/src/sacp/src/schema/agent_to_client/requests.rs
@@ -1,342 +1,44 @@
-use serde::Serialize;
-
-use crate::jsonrpc::{JsonRpcMessage, JsonRpcRequest, JsonRpcResponse};
 use crate::schema::{
-    CreateTerminalRequest, CreateTerminalResponse, KillTerminalRequest,
-    KillTerminalResponse, ReadTextFileRequest, ReadTextFileResponse, ReleaseTerminalRequest,
-    ReleaseTerminalResponse, RequestPermissionRequest, RequestPermissionResponse,
-    TerminalOutputRequest, TerminalOutputResponse, WaitForTerminalExitRequest,
-    WaitForTerminalExitResponse, WriteTextFileRequest, WriteTextFileResponse,
+    CreateTerminalRequest, CreateTerminalResponse, KillTerminalRequest, KillTerminalResponse,
+    ReadTextFileRequest, ReadTextFileResponse, ReleaseTerminalRequest, ReleaseTerminalResponse,
+    RequestPermissionRequest, RequestPermissionResponse, TerminalOutputRequest,
+    TerminalOutputResponse, WaitForTerminalExitRequest, WaitForTerminalExitResponse,
+    WriteTextFileRequest, WriteTextFileResponse,
 };
-use crate::util::json_cast;
 
-// Agent -> Client requests
-// These are messages that agents send to clients/editors
-
-// ============================================================================
-// RequestPermissionRequest
-// ============================================================================
-
-const METHOD_REQUEST_PERMISSION: &str = "session/request_permission";
-
-impl JsonRpcMessage for RequestPermissionRequest {
-    fn matches_method(method: &str) -> bool {
-        method == METHOD_REQUEST_PERMISSION
-    }
-
-    fn method(&self) -> &str {
-        METHOD_REQUEST_PERMISSION
-    }
-
-    fn to_untyped_message(&self) -> Result<crate::UntypedMessage, crate::Error> {
-        crate::UntypedMessage::new(self.method(), self)
-    }
-
-    fn parse_message(method: &str, params: &impl Serialize) -> Result<Self, crate::Error> {
-        if method != METHOD_REQUEST_PERMISSION {
-            return Err(crate::Error::method_not_found());
-        }
-        json_cast(params)
-    }
-}
-
-impl JsonRpcRequest for RequestPermissionRequest {
-    type Response = RequestPermissionResponse;
-}
-
-impl JsonRpcResponse for RequestPermissionResponse {
-    fn into_json(self, _method: &str) -> Result<serde_json::Value, crate::Error> {
-        serde_json::to_value(self).map_err(crate::Error::into_internal_error)
-    }
-
-    fn from_value(_method: &str, value: serde_json::Value) -> Result<Self, crate::Error> {
-        json_cast(&value)
-    }
-}
-
-// ============================================================================
-// WriteTextFileRequest
-// ============================================================================
-
-const METHOD_WRITE_TEXT_FILE: &str = "fs/write_text_file";
-
-impl JsonRpcMessage for WriteTextFileRequest {
-    fn matches_method(method: &str) -> bool {
-        method == METHOD_WRITE_TEXT_FILE
-    }
-
-    fn method(&self) -> &str {
-        METHOD_WRITE_TEXT_FILE
-    }
-
-    fn to_untyped_message(&self) -> Result<crate::UntypedMessage, crate::Error> {
-        crate::UntypedMessage::new(self.method(), self)
-    }
-
-    fn parse_message(method: &str, params: &impl Serialize) -> Result<Self, crate::Error> {
-        if method != METHOD_WRITE_TEXT_FILE {
-            return Err(crate::Error::method_not_found());
-        }
-        json_cast(params)
-    }
-}
-
-impl JsonRpcRequest for WriteTextFileRequest {
-    type Response = WriteTextFileResponse;
-}
-
-impl JsonRpcResponse for WriteTextFileResponse {
-    fn into_json(self, _method: &str) -> Result<serde_json::Value, crate::Error> {
-        serde_json::to_value(self).map_err(crate::Error::into_internal_error)
-    }
-
-    fn from_value(_method: &str, value: serde_json::Value) -> Result<Self, crate::Error> {
-        json_cast(&value)
-    }
-}
-
-// ============================================================================
-// ReadTextFileRequest
-// ============================================================================
-
-const METHOD_READ_TEXT_FILE: &str = "fs/read_text_file";
-
-impl JsonRpcMessage for ReadTextFileRequest {
-    fn matches_method(method: &str) -> bool {
-        method == METHOD_READ_TEXT_FILE
-    }
-
-    fn method(&self) -> &str {
-        METHOD_READ_TEXT_FILE
-    }
-
-    fn to_untyped_message(&self) -> Result<crate::UntypedMessage, crate::Error> {
-        crate::UntypedMessage::new(self.method(), self)
-    }
-
-    fn parse_message(method: &str, params: &impl Serialize) -> Result<Self, crate::Error> {
-        if method != METHOD_READ_TEXT_FILE {
-            return Err(crate::Error::method_not_found());
-        }
-        json_cast(params)
-    }
-}
-
-impl JsonRpcRequest for ReadTextFileRequest {
-    type Response = ReadTextFileResponse;
-}
-
-impl JsonRpcResponse for ReadTextFileResponse {
-    fn into_json(self, _method: &str) -> Result<serde_json::Value, crate::Error> {
-        serde_json::to_value(self).map_err(crate::Error::into_internal_error)
-    }
-
-    fn from_value(_method: &str, value: serde_json::Value) -> Result<Self, crate::Error> {
-        json_cast(&value)
-    }
-}
-
-// ============================================================================
-// CreateTerminalRequest
-// ============================================================================
-
-const METHOD_CREATE_TERMINAL: &str = "terminal/create";
-
-impl JsonRpcMessage for CreateTerminalRequest {
-    fn matches_method(method: &str) -> bool {
-        method == METHOD_CREATE_TERMINAL
-    }
-
-    fn method(&self) -> &str {
-        METHOD_CREATE_TERMINAL
-    }
-
-    fn to_untyped_message(&self) -> Result<crate::UntypedMessage, crate::Error> {
-        crate::UntypedMessage::new(self.method(), self)
-    }
-
-    fn parse_message(method: &str, params: &impl Serialize) -> Result<Self, crate::Error> {
-        if method != METHOD_CREATE_TERMINAL {
-            return Err(crate::Error::method_not_found());
-        }
-        json_cast(params)
-    }
-}
-
-impl JsonRpcRequest for CreateTerminalRequest {
-    type Response = CreateTerminalResponse;
-}
-
-impl JsonRpcResponse for CreateTerminalResponse {
-    fn into_json(self, _method: &str) -> Result<serde_json::Value, crate::Error> {
-        serde_json::to_value(self).map_err(crate::Error::into_internal_error)
-    }
-
-    fn from_value(_method: &str, value: serde_json::Value) -> Result<Self, crate::Error> {
-        json_cast(&value)
-    }
-}
-
-// ============================================================================
-// TerminalOutputRequest
-// ============================================================================
-
-const METHOD_TERMINAL_OUTPUT: &str = "terminal/output";
-
-impl JsonRpcMessage for TerminalOutputRequest {
-    fn matches_method(method: &str) -> bool {
-        method == METHOD_TERMINAL_OUTPUT
-    }
-
-    fn method(&self) -> &str {
-        METHOD_TERMINAL_OUTPUT
-    }
-
-    fn to_untyped_message(&self) -> Result<crate::UntypedMessage, crate::Error> {
-        crate::UntypedMessage::new(self.method(), self)
-    }
-
-    fn parse_message(method: &str, params: &impl Serialize) -> Result<Self, crate::Error> {
-        if method != METHOD_TERMINAL_OUTPUT {
-            return Err(crate::Error::method_not_found());
-        }
-        json_cast(params)
-    }
-}
-
-impl JsonRpcRequest for TerminalOutputRequest {
-    type Response = TerminalOutputResponse;
-}
-
-impl JsonRpcResponse for TerminalOutputResponse {
-    fn into_json(self, _method: &str) -> Result<serde_json::Value, crate::Error> {
-        serde_json::to_value(self).map_err(crate::Error::into_internal_error)
-    }
-
-    fn from_value(_method: &str, value: serde_json::Value) -> Result<Self, crate::Error> {
-        json_cast(&value)
-    }
-}
-
-// ============================================================================
-// ReleaseTerminalRequest
-// ============================================================================
-
-const METHOD_RELEASE_TERMINAL: &str = "terminal/release";
-
-impl JsonRpcMessage for ReleaseTerminalRequest {
-    fn matches_method(method: &str) -> bool {
-        method == METHOD_RELEASE_TERMINAL
-    }
-
-    fn method(&self) -> &str {
-        METHOD_RELEASE_TERMINAL
-    }
-
-    fn to_untyped_message(&self) -> Result<crate::UntypedMessage, crate::Error> {
-        crate::UntypedMessage::new(self.method(), self)
-    }
-
-    fn parse_message(method: &str, params: &impl Serialize) -> Result<Self, crate::Error> {
-        if method != METHOD_RELEASE_TERMINAL {
-            return Err(crate::Error::method_not_found());
-        }
-        json_cast(params)
-    }
-}
-
-impl JsonRpcRequest for ReleaseTerminalRequest {
-    type Response = ReleaseTerminalResponse;
-}
-
-impl JsonRpcResponse for ReleaseTerminalResponse {
-    fn into_json(self, _method: &str) -> Result<serde_json::Value, crate::Error> {
-        serde_json::to_value(self).map_err(crate::Error::into_internal_error)
-    }
-
-    fn from_value(_method: &str, value: serde_json::Value) -> Result<Self, crate::Error> {
-        json_cast(&value)
-    }
-}
-
-// ============================================================================
-// WaitForTerminalExitRequest
-// ============================================================================
-
-const METHOD_WAIT_FOR_TERMINAL_EXIT: &str = "terminal/wait_for_exit";
-
-impl JsonRpcMessage for WaitForTerminalExitRequest {
-    fn matches_method(method: &str) -> bool {
-        method == METHOD_WAIT_FOR_TERMINAL_EXIT
-    }
-
-    fn method(&self) -> &str {
-        METHOD_WAIT_FOR_TERMINAL_EXIT
-    }
-
-    fn to_untyped_message(&self) -> Result<crate::UntypedMessage, crate::Error> {
-        crate::UntypedMessage::new(self.method(), self)
-    }
-
-    fn parse_message(method: &str, params: &impl Serialize) -> Result<Self, crate::Error> {
-        if method != METHOD_WAIT_FOR_TERMINAL_EXIT {
-            return Err(crate::Error::method_not_found());
-        }
-        json_cast(params)
-    }
-}
-
-impl JsonRpcRequest for WaitForTerminalExitRequest {
-    type Response = WaitForTerminalExitResponse;
-}
-
-impl JsonRpcResponse for WaitForTerminalExitResponse {
-    fn into_json(self, _method: &str) -> Result<serde_json::Value, crate::Error> {
-        serde_json::to_value(self).map_err(crate::Error::into_internal_error)
-    }
-
-    fn from_value(_method: &str, value: serde_json::Value) -> Result<Self, crate::Error> {
-        json_cast(&value)
-    }
-}
-
-// ============================================================================
-// KillTerminalRequest
-// ============================================================================
-
-const METHOD_KILL_TERMINAL: &str = "terminal/kill";
-
-impl JsonRpcMessage for KillTerminalRequest {
-    fn matches_method(method: &str) -> bool {
-        method == METHOD_KILL_TERMINAL
-    }
-
-    fn method(&self) -> &str {
-        METHOD_KILL_TERMINAL
-    }
-
-    fn to_untyped_message(&self) -> Result<crate::UntypedMessage, crate::Error> {
-        crate::UntypedMessage::new(self.method(), self)
-    }
-
-    fn parse_message(method: &str, params: &impl Serialize) -> Result<Self, crate::Error> {
-        if method != METHOD_KILL_TERMINAL {
-            return Err(crate::Error::method_not_found());
-        }
-        json_cast(params)
-    }
-}
-
-impl JsonRpcRequest for KillTerminalRequest {
-    type Response = KillTerminalResponse;
-}
-
-impl JsonRpcResponse for KillTerminalResponse {
-    fn into_json(self, _method: &str) -> Result<serde_json::Value, crate::Error> {
-        serde_json::to_value(self).map_err(crate::Error::into_internal_error)
-    }
-
-    fn from_value(_method: &str, value: serde_json::Value) -> Result<Self, crate::Error> {
-        json_cast(&value)
-    }
-}
+impl_jsonrpc_request!(
+    RequestPermissionRequest,
+    RequestPermissionResponse,
+    "session/request_permission"
+);
+impl_jsonrpc_request!(
+    WriteTextFileRequest,
+    WriteTextFileResponse,
+    "fs/write_text_file"
+);
+impl_jsonrpc_request!(
+    ReadTextFileRequest,
+    ReadTextFileResponse,
+    "fs/read_text_file"
+);
+impl_jsonrpc_request!(
+    CreateTerminalRequest,
+    CreateTerminalResponse,
+    "terminal/create"
+);
+impl_jsonrpc_request!(
+    TerminalOutputRequest,
+    TerminalOutputResponse,
+    "terminal/output"
+);
+impl_jsonrpc_request!(
+    ReleaseTerminalRequest,
+    ReleaseTerminalResponse,
+    "terminal/release"
+);
+impl_jsonrpc_request!(
+    WaitForTerminalExitRequest,
+    WaitForTerminalExitResponse,
+    "terminal/wait_for_exit"
+);
+impl_jsonrpc_request!(KillTerminalRequest, KillTerminalResponse, "terminal/kill");

--- a/src/sacp/src/schema/client_to_agent/notifications.rs
+++ b/src/sacp/src/schema/client_to_agent/notifications.rs
@@ -1,30 +1,3 @@
 use crate::schema::CancelNotification;
-use serde::Serialize;
 
-use crate::jsonrpc::{JsonRpcMessage, JsonRpcNotification};
-use crate::util::json_cast;
-
-const METHOD_SESSION_CANCEL: &str = "session/cancel";
-
-impl JsonRpcMessage for CancelNotification {
-    fn matches_method(method: &str) -> bool {
-        method == METHOD_SESSION_CANCEL
-    }
-
-    fn method(&self) -> &str {
-        METHOD_SESSION_CANCEL
-    }
-
-    fn to_untyped_message(&self) -> Result<crate::UntypedMessage, crate::Error> {
-        crate::UntypedMessage::new(self.method(), self)
-    }
-
-    fn parse_message(method: &str, params: &impl Serialize) -> Result<Self, crate::Error> {
-        if !Self::matches_method(method) {
-            return Err(crate::Error::method_not_found());
-        }
-        json_cast(params)
-    }
-}
-
-impl JsonRpcNotification for CancelNotification {}
+impl_jsonrpc_notification!(CancelNotification, "session/cancel");

--- a/src/sacp/src/schema/client_to_agent/requests.rs
+++ b/src/sacp/src/schema/client_to_agent/requests.rs
@@ -1,292 +1,49 @@
 use crate::schema::{
     AuthenticateRequest, AuthenticateResponse, InitializeRequest, InitializeResponse,
-    LoadSessionRequest, LoadSessionResponse, NewSessionRequest, NewSessionResponse, PromptRequest,
-    PromptResponse, SetSessionConfigOptionRequest, SetSessionConfigOptionResponse,
-    SetSessionModeRequest, SetSessionModeResponse,
+    ListSessionsRequest, ListSessionsResponse, LoadSessionRequest, LoadSessionResponse,
+    NewSessionRequest, NewSessionResponse, PromptRequest, PromptResponse,
+    SetSessionConfigOptionRequest, SetSessionConfigOptionResponse, SetSessionModeRequest,
+    SetSessionModeResponse,
 };
-use serde::Serialize;
+#[cfg(feature = "unstable_session_close")]
+use crate::schema::{CloseSessionRequest, CloseSessionResponse};
+#[cfg(feature = "unstable_session_fork")]
+use crate::schema::{ForkSessionRequest, ForkSessionResponse};
+#[cfg(feature = "unstable_session_resume")]
+use crate::schema::{ResumeSessionRequest, ResumeSessionResponse};
+#[cfg(feature = "unstable_session_model")]
+use crate::schema::{SetSessionModelRequest, SetSessionModelResponse};
 
-use crate::jsonrpc::{JsonRpcMessage, JsonRpcRequest, JsonRpcResponse};
-use crate::util::json_cast;
+impl_jsonrpc_request!(InitializeRequest, InitializeResponse, "initialize");
+impl_jsonrpc_request!(AuthenticateRequest, AuthenticateResponse, "authenticate");
+impl_jsonrpc_request!(LoadSessionRequest, LoadSessionResponse, "session/load");
+impl_jsonrpc_request!(ListSessionsRequest, ListSessionsResponse, "session/list");
+impl_jsonrpc_request!(NewSessionRequest, NewSessionResponse, "session/new");
+impl_jsonrpc_request!(PromptRequest, PromptResponse, "session/prompt");
+impl_jsonrpc_request!(
+    SetSessionModeRequest,
+    SetSessionModeResponse,
+    "session/set_mode"
+);
+impl_jsonrpc_request!(
+    SetSessionConfigOptionRequest,
+    SetSessionConfigOptionResponse,
+    "session/set_config_option"
+);
 
-// Method constants
-const METHOD_INITIALIZE: &str = "initialize";
-const METHOD_AUTHENTICATE: &str = "authenticate";
-const METHOD_SESSION_LOAD: &str = "session/load";
-const METHOD_SESSION_NEW: &str = "session/new";
-const METHOD_SESSION_PROMPT: &str = "session/prompt";
-const METHOD_SESSION_SET_MODE: &str = "session/set_mode";
-const METHOD_SESSION_SET_CONFIG_OPTION: &str = "session/set_config_option";
-
-// ============================================================================
-// InitializeRequest
-// ============================================================================
-
-impl JsonRpcMessage for InitializeRequest {
-    fn matches_method(method: &str) -> bool {
-        method == METHOD_INITIALIZE
-    }
-
-    fn method(&self) -> &str {
-        METHOD_INITIALIZE
-    }
-
-    fn to_untyped_message(&self) -> Result<crate::UntypedMessage, crate::Error> {
-        crate::UntypedMessage::new(self.method(), self)
-    }
-
-    fn parse_message(method: &str, params: &impl Serialize) -> Result<Self, crate::Error> {
-        if !Self::matches_method(method) {
-            return Err(crate::Error::method_not_found());
-        }
-        json_cast(params)
-    }
-}
-
-impl JsonRpcRequest for InitializeRequest {
-    type Response = InitializeResponse;
-}
-
-impl JsonRpcResponse for InitializeResponse {
-    fn into_json(self, _method: &str) -> Result<serde_json::Value, crate::Error> {
-        serde_json::to_value(self).map_err(crate::Error::into_internal_error)
-    }
-
-    fn from_value(_method: &str, value: serde_json::Value) -> Result<Self, crate::Error> {
-        json_cast(&value)
-    }
-}
-
-// ============================================================================
-// AuthenticateRequest
-// ============================================================================
-
-impl JsonRpcMessage for AuthenticateRequest {
-    fn matches_method(method: &str) -> bool {
-        method == METHOD_AUTHENTICATE
-    }
-
-    fn method(&self) -> &str {
-        METHOD_AUTHENTICATE
-    }
-
-    fn to_untyped_message(&self) -> Result<crate::UntypedMessage, crate::Error> {
-        crate::UntypedMessage::new(self.method(), self)
-    }
-
-    fn parse_message(method: &str, params: &impl Serialize) -> Result<Self, crate::Error> {
-        if !Self::matches_method(method) {
-            return Err(crate::Error::method_not_found());
-        }
-        json_cast(params)
-    }
-}
-
-impl JsonRpcRequest for AuthenticateRequest {
-    type Response = AuthenticateResponse;
-}
-
-impl JsonRpcResponse for AuthenticateResponse {
-    fn into_json(self, _method: &str) -> Result<serde_json::Value, crate::Error> {
-        serde_json::to_value(self).map_err(crate::Error::into_internal_error)
-    }
-
-    fn from_value(_method: &str, value: serde_json::Value) -> Result<Self, crate::Error> {
-        json_cast(&value)
-    }
-}
-
-// ============================================================================
-// LoadSessionRequest
-// ============================================================================
-
-impl JsonRpcMessage for LoadSessionRequest {
-    fn matches_method(method: &str) -> bool {
-        method == METHOD_SESSION_LOAD
-    }
-
-    fn method(&self) -> &str {
-        METHOD_SESSION_LOAD
-    }
-
-    fn to_untyped_message(&self) -> Result<crate::UntypedMessage, crate::Error> {
-        crate::UntypedMessage::new(self.method(), self)
-    }
-
-    fn parse_message(method: &str, params: &impl Serialize) -> Result<Self, crate::Error> {
-        if !Self::matches_method(method) {
-            return Err(crate::Error::method_not_found());
-        }
-        json_cast(params)
-    }
-}
-
-impl JsonRpcRequest for LoadSessionRequest {
-    type Response = LoadSessionResponse;
-}
-
-impl JsonRpcResponse for LoadSessionResponse {
-    fn into_json(self, _method: &str) -> Result<serde_json::Value, crate::Error> {
-        serde_json::to_value(self).map_err(crate::Error::into_internal_error)
-    }
-
-    fn from_value(_method: &str, value: serde_json::Value) -> Result<Self, crate::Error> {
-        json_cast(&value)
-    }
-}
-
-// ============================================================================
-// NewSessionRequest
-// ============================================================================
-
-impl JsonRpcMessage for NewSessionRequest {
-    fn matches_method(method: &str) -> bool {
-        method == METHOD_SESSION_NEW
-    }
-
-    fn method(&self) -> &str {
-        METHOD_SESSION_NEW
-    }
-
-    fn to_untyped_message(&self) -> Result<crate::UntypedMessage, crate::Error> {
-        crate::UntypedMessage::new(self.method(), self)
-    }
-
-    fn parse_message(method: &str, params: &impl Serialize) -> Result<Self, crate::Error> {
-        if !Self::matches_method(method) {
-            return Err(crate::Error::method_not_found());
-        }
-        json_cast(params)
-    }
-}
-
-impl JsonRpcRequest for NewSessionRequest {
-    type Response = NewSessionResponse;
-}
-
-impl JsonRpcResponse for NewSessionResponse {
-    fn into_json(self, _method: &str) -> Result<serde_json::Value, crate::Error> {
-        serde_json::to_value(self).map_err(crate::Error::into_internal_error)
-    }
-
-    fn from_value(_method: &str, value: serde_json::Value) -> Result<Self, crate::Error> {
-        json_cast(&value)
-    }
-}
-
-// ============================================================================
-// PromptRequest
-// ============================================================================
-
-impl JsonRpcMessage for PromptRequest {
-    fn matches_method(method: &str) -> bool {
-        method == METHOD_SESSION_PROMPT
-    }
-
-    fn method(&self) -> &str {
-        METHOD_SESSION_PROMPT
-    }
-
-    fn to_untyped_message(&self) -> Result<crate::UntypedMessage, crate::Error> {
-        crate::UntypedMessage::new(self.method(), self)
-    }
-
-    fn parse_message(method: &str, params: &impl Serialize) -> Result<Self, crate::Error> {
-        if !Self::matches_method(method) {
-            return Err(crate::Error::method_not_found());
-        }
-        json_cast(params)
-    }
-}
-
-impl JsonRpcRequest for PromptRequest {
-    type Response = PromptResponse;
-}
-
-impl JsonRpcResponse for PromptResponse {
-    fn into_json(self, _method: &str) -> Result<serde_json::Value, crate::Error> {
-        serde_json::to_value(self).map_err(crate::Error::into_internal_error)
-    }
-
-    fn from_value(_method: &str, value: serde_json::Value) -> Result<Self, crate::Error> {
-        json_cast(&value)
-    }
-}
-
-// ============================================================================
-// SetSessionModeRequest
-// ============================================================================
-
-impl JsonRpcMessage for SetSessionModeRequest {
-    fn matches_method(method: &str) -> bool {
-        method == METHOD_SESSION_SET_MODE
-    }
-
-    fn method(&self) -> &str {
-        METHOD_SESSION_SET_MODE
-    }
-
-    fn to_untyped_message(&self) -> Result<crate::UntypedMessage, crate::Error> {
-        crate::UntypedMessage::new(self.method(), self)
-    }
-
-    fn parse_message(method: &str, params: &impl Serialize) -> Result<Self, crate::Error> {
-        if !Self::matches_method(method) {
-            return Err(crate::Error::method_not_found());
-        }
-        json_cast(params)
-    }
-}
-
-impl JsonRpcRequest for SetSessionModeRequest {
-    type Response = SetSessionModeResponse;
-}
-
-impl JsonRpcResponse for SetSessionModeResponse {
-    fn into_json(self, _method: &str) -> Result<serde_json::Value, crate::Error> {
-        serde_json::to_value(self).map_err(crate::Error::into_internal_error)
-    }
-
-    fn from_value(_method: &str, value: serde_json::Value) -> Result<Self, crate::Error> {
-        json_cast(&value)
-    }
-}
-
-// ============================================================================
-// SetSessionConfigOptionRequest
-// ============================================================================
-
-impl JsonRpcMessage for SetSessionConfigOptionRequest {
-    fn matches_method(method: &str) -> bool {
-        method == METHOD_SESSION_SET_CONFIG_OPTION
-    }
-
-    fn method(&self) -> &str {
-        METHOD_SESSION_SET_CONFIG_OPTION
-    }
-
-    fn to_untyped_message(&self) -> Result<crate::UntypedMessage, crate::Error> {
-        crate::UntypedMessage::new(self.method(), self)
-    }
-
-    fn parse_message(method: &str, params: &impl Serialize) -> Result<Self, crate::Error> {
-        if !Self::matches_method(method) {
-            return Err(crate::Error::method_not_found());
-        }
-        json_cast(params)
-    }
-}
-
-impl JsonRpcRequest for SetSessionConfigOptionRequest {
-    type Response = SetSessionConfigOptionResponse;
-}
-
-impl JsonRpcResponse for SetSessionConfigOptionResponse {
-    fn into_json(self, _method: &str) -> Result<serde_json::Value, crate::Error> {
-        serde_json::to_value(self).map_err(crate::Error::into_internal_error)
-    }
-
-    fn from_value(_method: &str, value: serde_json::Value) -> Result<Self, crate::Error> {
-        json_cast(&value)
-    }
-}
+#[cfg(feature = "unstable_session_model")]
+impl_jsonrpc_request!(
+    SetSessionModelRequest,
+    SetSessionModelResponse,
+    "session/set_model"
+);
+#[cfg(feature = "unstable_session_fork")]
+impl_jsonrpc_request!(ForkSessionRequest, ForkSessionResponse, "session/fork");
+#[cfg(feature = "unstable_session_resume")]
+impl_jsonrpc_request!(
+    ResumeSessionRequest,
+    ResumeSessionResponse,
+    "session/resume"
+);
+#[cfg(feature = "unstable_session_close")]
+impl_jsonrpc_request!(CloseSessionRequest, CloseSessionResponse, "session/close");

--- a/src/sacp/src/schema/enum_impls.rs
+++ b/src/sacp/src/schema/enum_impls.rs
@@ -1,216 +1,54 @@
-//! JsonRpcRequest and JsonRpcNotification implementations for ACP enum types.
-//!
-//! This module implements the JSON-RPC traits for the enum types from
-//! agent-client-protocol-schema that represent all possible messages:
-//! - ClientRequest/AgentResponse (messages agents receive/send)
-//! - ClientNotification (notifications agents receive)
-//! - AgentRequest/ClientResponse (messages clients receive/send)
-//! - AgentNotification (notifications clients receive)
+//! JsonRpcMessage and JsonRpcNotification/JsonRpcRequest implementations for
+//! the ACP enum types from agent-client-protocol-schema.
 
 use crate::schema::{AgentNotification, AgentRequest, ClientNotification, ClientRequest};
-use serde::Serialize;
-
-use crate::jsonrpc::{JsonRpcMessage, JsonRpcNotification, JsonRpcRequest};
-use crate::util::json_cast;
 
 // ============================================================================
 // Agent side (messages that agents receive)
 // ============================================================================
 
-impl JsonRpcMessage for ClientRequest {
-    fn matches_method(_method: &str) -> bool {
-        // Enum types match any method - the parsing will determine if it's valid
-        true
-    }
+impl_jsonrpc_request_enum!(ClientRequest {
+    InitializeRequest => "initialize",
+    AuthenticateRequest => "authenticate",
+    NewSessionRequest => "session/new",
+    LoadSessionRequest => "session/load",
+    ListSessionsRequest => "session/list",
+    #[cfg(feature = "unstable_session_fork")]
+    ForkSessionRequest => "session/fork",
+    #[cfg(feature = "unstable_session_resume")]
+    ResumeSessionRequest => "session/resume",
+    #[cfg(feature = "unstable_session_close")]
+    CloseSessionRequest => "session/close",
+    SetSessionModeRequest => "session/set_mode",
+    SetSessionConfigOptionRequest => "session/set_config_option",
+    PromptRequest => "session/prompt",
+    #[cfg(feature = "unstable_session_model")]
+    SetSessionModelRequest => "session/set_model",
+    [ext] ExtMethodRequest,
+});
 
-    fn method(&self) -> &str {
-        match self {
-            ClientRequest::InitializeRequest(_) => "initialize",
-            ClientRequest::AuthenticateRequest(_) => "authenticate",
-            ClientRequest::NewSessionRequest(_) => "session/new",
-            ClientRequest::LoadSessionRequest(_) => "session/load",
-            ClientRequest::SetSessionModeRequest(_) => "session/set_mode",
-            ClientRequest::SetSessionConfigOptionRequest(_) => "session/set_config_option",
-            ClientRequest::PromptRequest(_) => "session/prompt",
-            ClientRequest::ExtMethodRequest(ext) => &ext.method,
-            _ => "_unknown",
-        }
-    }
-
-    fn to_untyped_message(&self) -> Result<crate::UntypedMessage, crate::Error> {
-        crate::UntypedMessage::new(self.method(), self)
-    }
-
-    fn parse_message(method: &str, params: &impl Serialize) -> Result<Self, crate::Error> {
-        match method {
-            "initialize" => json_cast(params).map(ClientRequest::InitializeRequest),
-            "authenticate" => json_cast(params).map(ClientRequest::AuthenticateRequest),
-            "session/new" => json_cast(params).map(ClientRequest::NewSessionRequest),
-            "session/load" => json_cast(params).map(ClientRequest::LoadSessionRequest),
-            "session/set_mode" => json_cast(params).map(ClientRequest::SetSessionModeRequest),
-            "session/set_config_option" => json_cast(params).map(ClientRequest::SetSessionConfigOptionRequest),
-            "session/prompt" => json_cast(params).map(ClientRequest::PromptRequest),
-            _ => {
-                // Check for extension methods (prefixed with underscore)
-                if let Some(custom_method) = method.strip_prefix('_') {
-                    json_cast(params).map(|ext_req: crate::schema::ExtRequest| {
-                        ClientRequest::ExtMethodRequest(crate::schema::ExtRequest::new(
-                            custom_method.to_string(),
-                            ext_req.params,
-                        ))
-                    })
-                } else {
-                    Err(crate::Error::method_not_found())
-                }
-            }
-        }
-    }
-}
-
-impl JsonRpcRequest for ClientRequest {
-    type Response = serde_json::Value;
-}
-
-impl JsonRpcMessage for ClientNotification {
-    fn matches_method(_method: &str) -> bool {
-        // Enum types match any method - the parsing will determine if it's valid
-        true
-    }
-
-    fn method(&self) -> &str {
-        match self {
-            ClientNotification::CancelNotification(_) => "session/cancel",
-            ClientNotification::ExtNotification(ext) => &ext.method,
-            _ => "_unknown",
-        }
-    }
-
-    fn to_untyped_message(&self) -> Result<crate::UntypedMessage, crate::Error> {
-        crate::UntypedMessage::new(self.method(), self)
-    }
-
-    fn parse_message(method: &str, params: &impl Serialize) -> Result<Self, crate::Error> {
-        match method {
-            "session/cancel" => json_cast(params).map(ClientNotification::CancelNotification),
-            _ => {
-                // Check for extension notifications (prefixed with underscore)
-                if let Some(custom_method) = method.strip_prefix('_') {
-                    json_cast(params).map(|ext_notif: crate::schema::ExtNotification| {
-                        ClientNotification::ExtNotification(crate::schema::ExtNotification::new(
-                            custom_method.to_string(),
-                            ext_notif.params,
-                        ))
-                    })
-                } else {
-                    Err(crate::Error::method_not_found())
-                }
-            }
-        }
-    }
-}
-
-impl JsonRpcNotification for ClientNotification {}
+impl_jsonrpc_notification_enum!(ClientNotification {
+    CancelNotification => "session/cancel",
+    [ext] ExtNotification,
+});
 
 // ============================================================================
 // Client side (messages that clients/editors receive)
 // ============================================================================
 
-impl JsonRpcMessage for AgentRequest {
-    fn matches_method(_method: &str) -> bool {
-        // Enum types match any method - the parsing will determine if it's valid
-        true
-    }
+impl_jsonrpc_request_enum!(AgentRequest {
+    WriteTextFileRequest => "fs/write_text_file",
+    ReadTextFileRequest => "fs/read_text_file",
+    RequestPermissionRequest => "session/request_permission",
+    CreateTerminalRequest => "terminal/create",
+    TerminalOutputRequest => "terminal/output",
+    ReleaseTerminalRequest => "terminal/release",
+    WaitForTerminalExitRequest => "terminal/wait_for_exit",
+    KillTerminalRequest => "terminal/kill",
+    [ext] ExtMethodRequest,
+});
 
-    fn method(&self) -> &str {
-        match self {
-            AgentRequest::WriteTextFileRequest(_) => "fs/write_text_file",
-            AgentRequest::ReadTextFileRequest(_) => "fs/read_text_file",
-            AgentRequest::RequestPermissionRequest(_) => "session/request_permission",
-            AgentRequest::CreateTerminalRequest(_) => "terminal/create",
-            AgentRequest::TerminalOutputRequest(_) => "terminal/output",
-            AgentRequest::ReleaseTerminalRequest(_) => "terminal/release",
-            AgentRequest::WaitForTerminalExitRequest(_) => "terminal/wait_for_exit",
-            AgentRequest::KillTerminalRequest(_) => "terminal/kill",
-            AgentRequest::ExtMethodRequest(ext) => &ext.method,
-            _ => "_unknown",
-        }
-    }
-
-    fn to_untyped_message(&self) -> Result<crate::UntypedMessage, crate::Error> {
-        crate::UntypedMessage::new(self.method(), self)
-    }
-
-    fn parse_message(method: &str, params: &impl Serialize) -> Result<Self, crate::Error> {
-        match method {
-            "fs/write_text_file" => json_cast(params).map(AgentRequest::WriteTextFileRequest),
-            "fs/read_text_file" => json_cast(params).map(AgentRequest::ReadTextFileRequest),
-            "session/request_permission" => {
-                json_cast(params).map(AgentRequest::RequestPermissionRequest)
-            }
-            "terminal/create" => json_cast(params).map(AgentRequest::CreateTerminalRequest),
-            "terminal/output" => json_cast(params).map(AgentRequest::TerminalOutputRequest),
-            "terminal/release" => json_cast(params).map(AgentRequest::ReleaseTerminalRequest),
-            "terminal/wait_for_exit" => {
-                json_cast(params).map(AgentRequest::WaitForTerminalExitRequest)
-            }
-            "terminal/kill" => json_cast(params).map(AgentRequest::KillTerminalRequest),
-            _ => {
-                // Check for extension methods (prefixed with underscore)
-                if let Some(custom_method) = method.strip_prefix('_') {
-                    json_cast(params).map(|ext_req: crate::schema::ExtRequest| {
-                        AgentRequest::ExtMethodRequest(crate::schema::ExtRequest::new(
-                            custom_method.to_string(),
-                            ext_req.params,
-                        ))
-                    })
-                } else {
-                    Err(crate::Error::method_not_found())
-                }
-            }
-        }
-    }
-}
-
-impl JsonRpcRequest for AgentRequest {
-    type Response = serde_json::Value;
-}
-
-impl JsonRpcMessage for AgentNotification {
-    fn matches_method(_method: &str) -> bool {
-        // Enum types match any method - the parsing will determine if it's valid
-        true
-    }
-
-    fn method(&self) -> &str {
-        match self {
-            AgentNotification::SessionNotification(_) => "session/update",
-            AgentNotification::ExtNotification(ext) => &ext.method,
-            _ => "_unknown",
-        }
-    }
-
-    fn to_untyped_message(&self) -> Result<crate::UntypedMessage, crate::Error> {
-        crate::UntypedMessage::new(self.method(), self)
-    }
-
-    fn parse_message(method: &str, params: &impl Serialize) -> Result<Self, crate::Error> {
-        match method {
-            "session/update" => json_cast(params).map(AgentNotification::SessionNotification),
-            _ => {
-                // Check for extension notifications (prefixed with underscore)
-                if let Some(custom_method) = method.strip_prefix('_') {
-                    json_cast(params).map(|ext_notif: crate::schema::ExtNotification| {
-                        AgentNotification::ExtNotification(crate::schema::ExtNotification::new(
-                            custom_method.to_string(),
-                            ext_notif.params,
-                        ))
-                    })
-                } else {
-                    Err(crate::Error::method_not_found())
-                }
-            }
-        }
-    }
-}
-
-impl JsonRpcNotification for AgentNotification {}
+impl_jsonrpc_notification_enum!(AgentNotification {
+    SessionNotification => "session/update",
+    [ext] ExtNotification,
+});

--- a/src/sacp/src/schema/mod.rs
+++ b/src/sacp/src/schema/mod.rs
@@ -4,6 +4,221 @@
 //! including requests, responses, notifications, and supporting types.
 //! All types are re-exported flatly from this module.
 
+// ---------------------------------------------------------------------------
+// Macros for implementing JsonRpc traits on schema types
+// ---------------------------------------------------------------------------
+
+/// Implement `JsonRpcMessage`, `JsonRpcRequest`, and `JsonRpcResponse` for a
+/// request/response pair from the schema crate.
+///
+/// ```ignore
+/// impl_jsonrpc_request!(PromptRequest, PromptResponse, "session/prompt");
+/// ```
+macro_rules! impl_jsonrpc_request {
+    ($req:ty, $resp:ty, $method:literal) => {
+        impl $crate::JsonRpcMessage for $req {
+            fn matches_method(method: &str) -> bool {
+                method == $method
+            }
+
+            fn method(&self) -> &str {
+                $method
+            }
+
+            fn to_untyped_message(&self) -> Result<$crate::UntypedMessage, $crate::Error> {
+                $crate::UntypedMessage::new($method, self)
+            }
+
+            fn parse_message(
+                method: &str,
+                params: &impl serde::Serialize,
+            ) -> Result<Self, $crate::Error> {
+                if method != $method {
+                    return Err($crate::Error::method_not_found());
+                }
+                $crate::util::json_cast(params)
+            }
+        }
+
+        impl $crate::JsonRpcRequest for $req {
+            type Response = $resp;
+        }
+
+        impl $crate::JsonRpcResponse for $resp {
+            fn into_json(self, _method: &str) -> Result<serde_json::Value, $crate::Error> {
+                serde_json::to_value(self).map_err($crate::Error::into_internal_error)
+            }
+
+            fn from_value(_method: &str, value: serde_json::Value) -> Result<Self, $crate::Error> {
+                $crate::util::json_cast(&value)
+            }
+        }
+    };
+}
+
+/// Implement `JsonRpcMessage` and `JsonRpcNotification` for a notification type
+/// from the schema crate.
+///
+/// ```ignore
+/// impl_jsonrpc_notification!(CancelNotification, "session/cancel");
+/// ```
+macro_rules! impl_jsonrpc_notification {
+    ($notif:ty, $method:literal) => {
+        impl $crate::JsonRpcMessage for $notif {
+            fn matches_method(method: &str) -> bool {
+                method == $method
+            }
+
+            fn method(&self) -> &str {
+                $method
+            }
+
+            fn to_untyped_message(&self) -> Result<$crate::UntypedMessage, $crate::Error> {
+                $crate::UntypedMessage::new($method, self)
+            }
+
+            fn parse_message(
+                method: &str,
+                params: &impl serde::Serialize,
+            ) -> Result<Self, $crate::Error> {
+                if method != $method {
+                    return Err($crate::Error::method_not_found());
+                }
+                $crate::util::json_cast(params)
+            }
+        }
+
+        impl $crate::JsonRpcNotification for $notif {}
+    };
+}
+
+/// Implement `JsonRpcMessage` and `JsonRpcRequest` for an enum that dispatches
+/// across multiple request types, with an extension method fallback.
+///
+/// Variants can optionally have `#[cfg(...)]` attributes for conditional compilation.
+///
+/// ```ignore
+/// impl_jsonrpc_request_enum!(ClientRequest {
+///     InitializeRequest => "initialize",
+///     PromptRequest => "session/prompt",
+///     #[cfg(feature = "unstable_session_model")]
+///     SetSessionModelRequest => "session/set_model",
+///     [ext] ExtMethodRequest,
+/// });
+/// ```
+macro_rules! impl_jsonrpc_request_enum {
+    ($enum:ty {
+        $( $(#[$meta:meta])* $variant:ident => $method:literal, )*
+        [ext] $ext_variant:ident,
+    }) => {
+        impl $crate::JsonRpcMessage for $enum {
+            fn matches_method(_method: &str) -> bool {
+                true
+            }
+
+            fn method(&self) -> &str {
+                match self {
+                    $( $(#[$meta])* Self::$variant(_) => $method, )*
+                    Self::$ext_variant(ext) => &ext.method,
+                    _ => "_unknown",
+                }
+            }
+
+            fn to_untyped_message(&self) -> Result<$crate::UntypedMessage, $crate::Error> {
+                $crate::UntypedMessage::new(self.method(), self)
+            }
+
+            fn parse_message(
+                method: &str,
+                params: &impl serde::Serialize,
+            ) -> Result<Self, $crate::Error> {
+                match method {
+                    $( $(#[$meta])* $method => $crate::util::json_cast(params).map(Self::$variant), )*
+                    _ => {
+                        if let Some(custom_method) = method.strip_prefix('_') {
+                            $crate::util::json_cast(params).map(
+                                |ext_req: $crate::schema::ExtRequest| {
+                                    Self::$ext_variant($crate::schema::ExtRequest::new(
+                                        custom_method.to_string(),
+                                        ext_req.params,
+                                    ))
+                                },
+                            )
+                        } else {
+                            Err($crate::Error::method_not_found())
+                        }
+                    }
+                }
+            }
+        }
+
+        impl $crate::JsonRpcRequest for $enum {
+            type Response = serde_json::Value;
+        }
+    };
+}
+
+/// Implement `JsonRpcMessage` and `JsonRpcNotification` for an enum that
+/// dispatches across multiple notification types, with an extension fallback.
+///
+/// Variants can optionally have `#[cfg(...)]` attributes for conditional compilation.
+///
+/// ```ignore
+/// impl_jsonrpc_notification_enum!(AgentNotification {
+///     SessionNotification => "session/update",
+///     [ext] ExtNotification,
+/// });
+/// ```
+macro_rules! impl_jsonrpc_notification_enum {
+    ($enum:ty {
+        $( $(#[$meta:meta])* $variant:ident => $method:literal, )*
+        [ext] $ext_variant:ident,
+    }) => {
+        impl $crate::JsonRpcMessage for $enum {
+            fn matches_method(_method: &str) -> bool {
+                true
+            }
+
+            fn method(&self) -> &str {
+                match self {
+                    $( $(#[$meta])* Self::$variant(_) => $method, )*
+                    Self::$ext_variant(ext) => &ext.method,
+                    _ => "_unknown",
+                }
+            }
+
+            fn to_untyped_message(&self) -> Result<$crate::UntypedMessage, $crate::Error> {
+                $crate::UntypedMessage::new(self.method(), self)
+            }
+
+            fn parse_message(
+                method: &str,
+                params: &impl serde::Serialize,
+            ) -> Result<Self, $crate::Error> {
+                match method {
+                    $( $(#[$meta])* $method => $crate::util::json_cast(params).map(Self::$variant), )*
+                    _ => {
+                        if let Some(custom_method) = method.strip_prefix('_') {
+                            $crate::util::json_cast(params).map(
+                                |ext_notif: $crate::schema::ExtNotification| {
+                                    Self::$ext_variant($crate::schema::ExtNotification::new(
+                                        custom_method.to_string(),
+                                        ext_notif.params,
+                                    ))
+                                },
+                            )
+                        } else {
+                            Err($crate::Error::method_not_found())
+                        }
+                    }
+                }
+            }
+        }
+
+        impl $crate::JsonRpcNotification for $enum {}
+    };
+}
+
 // Internal organization
 mod agent_to_client;
 mod client_to_agent;


### PR DESCRIPTION
- Replace ~890 lines of repetitive trait implementations with concise macros
- Add impl_jsonrpc_request! and impl_jsonrpc_notification! macros in schema/mod.rs
- Add feature flags for unstable ACP methods (session_model, session_fork, etc.)
- All tests pass, no functional changes